### PR TITLE
Dockerfile changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir "rendercv[full]"
 WORKDIR /rendercv
 
 # Set the entrypoint to /bin/sh instead of Python
-CMD ["rendercv"]
+ENTRYPOINT ["rendercv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ RUN pip install --no-cache-dir "rendercv[full]"
 WORKDIR /rendercv
 
 # Set the entrypoint to /bin/sh instead of Python
-ENTRYPOINT ["/bin/bash"]
-
+CMD ["rendercv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.13-slim
 
 # Install RenderCV:
-RUN pip install "rendercv[full]"
+RUN pip install --no-cache-dir "rendercv[full]"
 
 # Create a directory for the app
 WORKDIR /rendercv


### PR DESCRIPTION
This PR changes the `pip install` call so it doesn't keep cache around.
This reduces the image size from 365MB to 307MB (~15.9%)

It also sets `ENTRYPOINT ["rendercv"]` as suggested in #353 