### PR TITLE
build: Add codespell pre-commit hook and correct various typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,7 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -283,7 +283,7 @@ RenderCV has transitioned from using $\LaTeX$ to Typst. RenderCV is now much fas
 
 ### Changed
 
-- `sb2nov` theme's $\LaTeX$ code has been changed completly. There are slight changes in the looks.
+- `sb2nov` theme's $\LaTeX$ code has been changed completely. There are slight changes in the looks.
 - `classic`, `sb2nov`, and `engineeringresumes` use the same $\LaTeX$ code base now.
 - The design option `show_last_updated_date` has been renamed to `disable_last_updated_date` for consistency.
 - Mastodon links now use the original hostnames instead of `https://mastodon.social/`.

--- a/examples/John_Doe_ClassicTheme_CV.yaml
+++ b/examples/John_Doe_ClassicTheme_CV.yaml
@@ -81,7 +81,7 @@ cv:
         location:
         summary:
         highlights:
-          - Instructed the "Statics" course on Udemy (60,000+ students, 200,000+ hours watched)
+          - Instructed the "Statistics" course on Udemy (60,000+ students, 200,000+ hours watched)
     skills:
       - label: Programming
         details: Proficient with Python, C++, and Git; good understanding of Web, app development, and DevOps

--- a/examples/John_Doe_EngineeringclassicTheme_CV.yaml
+++ b/examples/John_Doe_EngineeringclassicTheme_CV.yaml
@@ -81,7 +81,7 @@ cv:
         location:
         summary:
         highlights:
-          - Instructed the "Statics" course on Udemy (60,000+ students, 200,000+ hours watched)
+          - Instructed the "Statistics" course on Udemy (60,000+ students, 200,000+ hours watched)
     skills:
       - label: Programming
         details: Proficient with Python, C++, and Git; good understanding of Web, app development, and DevOps

--- a/examples/John_Doe_EngineeringresumesTheme_CV.yaml
+++ b/examples/John_Doe_EngineeringresumesTheme_CV.yaml
@@ -81,7 +81,7 @@ cv:
         location:
         summary:
         highlights:
-          - Instructed the "Statics" course on Udemy (60,000+ students, 200,000+ hours watched)
+          - Instructed the "Statistics" course on Udemy (60,000+ students, 200,000+ hours watched)
     skills:
       - label: Programming
         details: Proficient with Python, C++, and Git; good understanding of Web, app development, and DevOps

--- a/examples/John_Doe_ModerncvTheme_CV.yaml
+++ b/examples/John_Doe_ModerncvTheme_CV.yaml
@@ -81,7 +81,7 @@ cv:
         location:
         summary:
         highlights:
-          - Instructed the "Statics" course on Udemy (60,000+ students, 200,000+ hours watched)
+          - Instructed the "Statistics" course on Udemy (60,000+ students, 200,000+ hours watched)
     skills:
       - label: Programming
         details: Proficient with Python, C++, and Git; good understanding of Web, app development, and DevOps

--- a/examples/John_Doe_Sb2novTheme_CV.yaml
+++ b/examples/John_Doe_Sb2novTheme_CV.yaml
@@ -81,7 +81,7 @@ cv:
         location:
         summary:
         highlights:
-          - Instructed the "Statics" course on Udemy (60,000+ students, 200,000+ hours watched)
+          - Instructed the "Statistics" course on Udemy (60,000+ students, 200,000+ hours watched)
     skills:
       - label: Programming
         details: Proficient with Python, C++, and Git; good understanding of Web, app development, and DevOps

--- a/rendercv/data/models/design.py
+++ b/rendercv/data/models/design.py
@@ -31,7 +31,7 @@ def validate_design_options(
     available_theme_options: dict[str, type],
     available_entry_type_names: list[str],
 ) -> Any:
-    """Chech if the design options are for a built-in theme or a custom theme. If it is
+    """Check if the design options are for a built-in theme or a custom theme. If it is
     a built-in theme, validate it with the corresponding data model. If it is a custom
     theme, check if the necessary files are provided and validate it with the custom
     theme data model, found in the `__init__.py` file of the custom theme folder.

--- a/rendercv/data/sample_content.yaml
+++ b/rendercv/data/sample_content.yaml
@@ -64,7 +64,7 @@ sections:
     - name: "[Teaching on Udemy](https://example.com)"
       date: Fall 2023
       highlights:
-        - 'Instructed the "Statics" course on Udemy (60,000+ students, 200,000+ hours watched)'
+        - 'Instructed the "Statistics" course on Udemy (60,000+ students, 200,000+ hours watched)'
   skills:
     - label: Programming
       details: Proficient with Python, C++, and Git; good understanding of Web, app development, and DevOps

--- a/tests/test_hatch_scripts.py
+++ b/tests/test_hatch_scripts.py
@@ -22,14 +22,14 @@ import pytest
 )
 @pytest.mark.skip(reason="They fail on GitHub Actions")
 def test_scripts(script_name):
-    # If hatch is not installed, just pass the test (supress FileNotFoundError)
+    # If hatch is not installed, just pass the test (suppress FileNotFoundError)
     with contextlib.suppress(FileNotFoundError):
         subprocess.run(["hatch", "run", script_name], check=True)
 
 
 @pytest.mark.skip(reason="They fail on GitHub Actions")
 def test_executable():
-    # If hatch is not installed, just pass the test (supress FileNotFoundError)
+    # If hatch is not installed, just pass the test (suppress FileNotFoundError)
     with contextlib.suppress(FileNotFoundError):
         root = pathlib.Path(__file__).parent.parent
         bin_folder = root / "bin"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -677,7 +677,7 @@ def test_locale(
 def test_are_all_the_theme_files_the_same(theme_name):
     source_of_truth_theme = "classic"
 
-    # find the directiory of rendercv.themes.classic:
+    # find the directory of rendercv.themes.classic:
     source_of_truth_theme_folder = (
         pathlib.Path(__file__).parent.parent
         / "rendercv"
@@ -688,7 +688,7 @@ def test_are_all_the_theme_files_the_same(theme_name):
         file.read_text() for file in source_of_truth_theme_folder.rglob("*.j2.typ")
     ]
 
-    # find the directiory of rendercv.themes.{theme_name}:
+    # find the directory of rendercv.themes.{theme_name}:
     theme_folder = (
         pathlib.Path(__file__).parent.parent / "rendercv" / "themes" / theme_name
     )


### PR DESCRIPTION
Adding codespell to pre-commit will correct typos and keep the comments/docs fresh