### PR TITLE
feat: add --dont-generate-pdf/-nopdf CLI option

### DIFF
--- a/rendercv/cli/commands.py
+++ b/rendercv/cli/commands.py
@@ -134,6 +134,14 @@ def cli_command_render(
             help="Don't generate the PNG file",
         ),
     ] = False,
+    dont_generate_pdf: Annotated[
+        bool,
+        typer.Option(
+            "--dont-generate-pdf",
+            "-nopdf",
+            help="Don't generate the PDF file",
+        ),
+    ] = False,
     watch: Annotated[
         bool,
         typer.Option(

--- a/rendercv/cli/utilities.py
+++ b/rendercv/cli/utilities.py
@@ -311,7 +311,11 @@ def run_rendercv_with_printer(
     # 5. Create the Markdown file.
     # 6. Render HTML from Markdown.
     number_of_steps = 6
-    if render_command_settings_dict["dont_generate_png"]:
+    if render_command_settings_dict.get("dont_generate_pdf", False):
+        number_of_steps -= 1
+        # If PDF is not generated, PNG can't be generated either
+        number_of_steps -= 1
+    elif render_command_settings_dict["dont_generate_png"]:
         number_of_steps -= 1
 
     if render_command_settings_dict["dont_generate_markdown"]:
@@ -358,20 +362,21 @@ def run_rendercv_with_printer(
 
         progress.finish_the_current_step()
 
-        progress.start_a_step("Rendering the Typst file to a PDF")
+        if not render_command_settings.dont_generate_pdf:
+            progress.start_a_step("Rendering the Typst file to a PDF")
 
-        pdf_file_path_in_output_folder = renderer.render_a_pdf_from_typst(
-            typst_file_path_in_output_folder,
-        )
-        if render_command_settings.pdf_path:
-            copy_files(
-                pdf_file_path_in_output_folder,
-                render_command_settings.pdf_path,
+            pdf_file_path_in_output_folder = renderer.render_a_pdf_from_typst(
+                typst_file_path_in_output_folder,
             )
+            if render_command_settings.pdf_path:
+                copy_files(
+                    pdf_file_path_in_output_folder,
+                    render_command_settings.pdf_path,
+                )
 
-        progress.finish_the_current_step()
+            progress.finish_the_current_step()
 
-        if not render_command_settings.dont_generate_png:
+        if not render_command_settings.dont_generate_pdf and not render_command_settings.dont_generate_png:
             progress.start_a_step("Rendering PNG files from the PDF")
 
             png_file_paths_in_output_folder = renderer.render_pngs_from_typst(

--- a/rendercv/data/models/rendercv_settings.py
+++ b/rendercv/data/models/rendercv_settings.py
@@ -147,6 +147,15 @@ class RenderCommandSettings(RenderCVBaseModelWithoutExtraKeys):
         ),
     )
 
+    dont_generate_pdf: bool = pydantic.Field(
+        default=False,
+        title="Don't Generate PDF",
+        description=(
+            "A boolean value to determine whether the PDF file will be generated. The"
+            " default value is False."
+        ),
+    )
+
     watch: bool = pydantic.Field(
         default=False,
         title="Re-run RenderCV When the Input File is Updated",


### PR DESCRIPTION
## Summary
- Added new command-line switch `--dont-generate-pdf` (short form: `-nopdf`) to disable PDF generation
- The Typst file is still generated, allowing users to use it as an intermediate file for their own processing workflows
- When PDF generation is disabled, PNG generation is also automatically skipped since PNGs are rendered from the PDF

## Motivation
As requested in #481, this feature allows users to skip PDF generation when they only need the intermediate `.typ` file, similar to the existing `-nopng` option.

## Changes
- Added `dont_generate_pdf` field to `RenderCommandSettings` data model
- Added CLI option `--dont-generate-pdf`/`-nopdf` to the render command
- Updated `run_rendercv_with_printer` function to conditionally skip PDF generation
- Automatically skip PNG generation when PDF is not generated (since PNGs depend on PDF)

## Test Plan
- [x] Tested with `--dont-generate-pdf` flag - only generates .typ, .md, and .html files
- [x] Tested with `-nopdf` short form - works correctly
- [x] Tested default behavior (no flag) - still generates PDF as expected
- [x] Verified that PNG generation is automatically skipped when PDF is disabled
- [x] Fixed ruff linting issues (replaced dictionary key check with `dict.get()`)

Fixes #481