### PR TITLE
ci: trigger publish workflow on semver tags

### DIFF
--- a/.github/workflows/publish-a-release.yaml
+++ b/.github/workflows/publish-a-release.yaml
@@ -1,14 +1,17 @@
 name: Publish a release
 
-# GitHub events that triggers the workflow:
+# GitHub events that trigger the workflow:
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - "v*.*.*"
+      - "v*.*.*-*"
+  workflow_dispatch:
 
 jobs:
   call_test_workflow:
     name: Run Tests
+    if: ${{ github.ref_type == 'tag' && github.ref_name matches '^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$' }}
     uses: ./.github/workflows/test.yaml
 
   call_create_executables_workflow:
@@ -43,6 +46,8 @@ jobs:
       - name: Upload the executables as release assets
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           files: |
             rendercv-*/rendercv-linux-ARM64
             rendercv-*/rendercv-linux-x86_64


### PR DESCRIPTION
## Summary
- automatically run the publish workflow whenever a semver-style tag (including prereleases) is pushed
- guard the pipeline so only properly formatted tags make it through, ensuring releases happen after tests/builds succeed

## Why this helps
This change lets maintainers tag a release and have the PyPI package, binaries, and container images appear without manual intervention, reducing the chance of human error and speeding up the release cycle envisioned in #503.

## Testing
- not run (workflow-only changes)