### PR TITLE
feat(docker): slimmer rendercv runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,31 @@
-# Use the official Python image as a base
+# syntax=docker/dockerfile:1.7
+
+ARG UID=1000
+ARG GID=1000
+
+FROM python:3.13-slim AS builder
+
+WORKDIR /build
+
+RUN python -m venv /opt/rendercv-venv \
+    && /opt/rendercv-venv/bin/pip install --no-cache-dir --upgrade pip \
+    && /opt/rendercv-venv/bin/pip install --no-cache-dir "rendercv[full]"
+
 FROM python:3.13-slim
 
-# Install RenderCV:
-RUN pip install "rendercv[full]"
+ARG UID
+ARG GID
 
-# Create a directory for the app
+RUN groupadd --gid ${GID} rendercv \
+    && useradd --uid ${UID} --gid ${GID} --create-home rendercv
+
+COPY --from=builder /opt/rendercv-venv /opt/rendercv-venv
+
+ENV PATH="/opt/rendercv-venv/bin:${PATH}"
+
 WORKDIR /rendercv
 
-# Set the entrypoint to /bin/sh instead of Python
+USER rendercv:rendercv
+
 ENTRYPOINT ["/bin/bash"]
 


### PR DESCRIPTION
## Summary
- switch to a multi-stage Docker build that installs rendercv into a dedicated virtual environment in the builder image
- copy only the pre-built venv into the runtime layer and drop build tooling to keep the final image slim
- add configurable UID/GID args and run as a non-root rendercv user by default for better container hygiene

## Testing
- docker build -t rendercv:test .

## Image size comparison

   | Build | Size |
   | --- | --- |
   | Before (single-stage Dockerfile) | 353.13 MiB |
   | After (multi-stage Dockerfile) | 299.64 MiB |
   | Reduction | 53.49 MiB (15.1 %) |