### PR TITLE
Removed `__pycache__` from the output directory

### DIFF
--- a/rendercv/renderer/renderer.py
+++ b/rendercv/renderer/renderer.py
@@ -87,7 +87,7 @@ def copy_theme_files_to_output_directory(
         except TypeError:
             suffix = ""
 
-        if suffix not in dont_copy_files_with_these_extensions:
+        if suffix not in dont_copy_files_with_these_extensions and theme_file.name != "__pycache__":
             if theme_file.is_dir():
                 shutil.copytree(
                     str(theme_file),


### PR DESCRIPTION
Hello,

This pull request exclude the `__pycache__` Python directory from the output directory. Also see 