### PR TITLE
ci: auto-merge dependabot updates after tests pass

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,3 +87,40 @@ jobs:
           SMOKESHOW_GITHUB_COVERAGE_THRESHOLD: 90
           SMOKESHOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SMOKESHOW_GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+  dependabot-auto-merge:
+    name: Enable Dependabot auto-merge
+    needs: [test]
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.actor == 'dependabot[bot]' &&
+      github.repository == 'rendercv/rendercv'
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve Dependabot PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Skip semver-major update
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: echo "Skipping auto-merge for semver-major update."


### PR DESCRIPTION
## Summary
- Introduces a \ job that waits for the existing matrix to succeed and runs only on Dependabot-authored pull requests in this repository.
- Uses \ to detect update types, auto-approves non–semver-major updates with the GitHub CLI, and enables squash auto-merge for those PRs.
- Skips semver-major upgrades with a clear log message so maintainers keep manual control over riskier updates.

---

fixes: https://github.com/rendercv/rendercv/issues/510