### PR TITLE
ci(pytest): use pytest-xdist to run tests in parallel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,15 +99,16 @@ rendercv = 'rendercv.cli:app'
 # Virtual Environment Dependencies:
 [dependency-groups]
 dev = [
-    'ruff>=0.14.1',        # Lint and format the code
-    'black>=25.9.0',       # Format the code
-    'pyright>=1.1.406',    # Type checking
-    'pre-commit>=4.3.0',   # Run checks before committing
-    'pytest>=8.4.2',       # Run tests
-    'coverage>=7.11.0',    # Generate coverage reports
-    'pypdf>=6.1.3',        # Read PDF files
-    'snakeviz>=2.2.2',     # Profiling
+    'ruff>=0.14.1', # Lint and format the code
+    'black>=25.9.0', # Format the code
+    'pyright>=1.1.406', # Type checking
+    'pre-commit>=4.3.0', # Run checks before committing
+    'pytest>=8.4.2', # Run tests
+    'coverage>=7.11.0', # Generate coverage reports
+    'pypdf>=6.1.3', # Read PDF files
+    'snakeviz>=2.2.2', # Profiling
     'pyinstaller>=6.16.0', # Build executables
+    "pytest-xdist>=3.8.0",
 ]
 docs = [
     'mkdocs-material>=9.6.20',
@@ -200,10 +201,11 @@ exclude_lines = ['if __name__ == .__main__.:']
 log_cli_level = 'INFO'
 xfail_strict = true
 addopts = [
-    '-ra',              # Show extra test summary info
-    '-v',               # Increase verbosity
-    '--strict-markers', # Disallow unknown markers
-    '--strict-config',  # Fail on unknown config options
+    '-ra',                 # Show extra test summary info
+    '-v',                  # Increase verbosity
+    '--strict-markers',    # Disallow unknown markers
+    '--strict-config',     # Fail on unknown config options
+    '--numprocesses=auto', # Number of processes in parallel
 ]
 testpaths = ['tests']
 

--- a/uv.lock
+++ b/uv.lock
@@ -349,6 +349,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1187,6 +1196,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1325,6 +1347,7 @@ dev = [
     { name = "pypdf" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "snakeviz" },
 ]
@@ -1367,6 +1390,7 @@ dev = [
     { name = "pypdf", specifier = ">=6.1.3" },
     { name = "pyright", specifier = ">=1.1.406" },
     { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.14.1" },
     { name = "snakeviz", specifier = ">=2.2.2" },
 ]


### PR DESCRIPTION
This PR adds pytest-xdist to the dev dependencies, enabling tests to run in parallel. 

The results speak for themselves. The test speed increases until 4 cores, running 300% faster than 1 core. Pytest has some overhead, so the returns are diminishing.

```bash
❯ hyperfine \
  --warmup 1 \
  --runs 5 \
  --output ./xdist.log \
  --cleanup 'uv venv --clear' \
  --parameter-list NUM_CORES 1,2,4,8 \
  'uv run --no-cache --all-extras pytest -n {NUM_CORES}'
Benchmark 1: uv run --no-cache --all-extras pytest -n 1
  Time (mean ± σ):     65.714 s ±  0.663 s    [User: 54.790 s, System: 1.821 s]
  Range (min … max):   64.930 s … 66.769 s    5 runs

Benchmark 2: uv run --no-cache --all-extras pytest -n 2
  Time (mean ± σ):     47.109 s ±  0.392 s    [User: 59.101 s, System: 2.059 s]
  Range (min … max):   46.558 s … 47.499 s    5 runs

Benchmark 3: uv run --no-cache --all-extras pytest -n 4
  Time (mean ± σ):     22.895 s ±  0.229 s    [User: 74.406 s, System: 3.039 s]
  Range (min … max):   22.678 s … 23.268 s    5 runs

Benchmark 4: uv run --no-cache --all-extras pytest -n 8
  Time (mean ± σ):     22.849 s ±  0.948 s    [User: 117.652 s, System: 5.316 s]
  Range (min … max):   22.125 s … 24.493 s    5 runs

Summary
  uv run --no-cache --all-extras pytest -n 8 ran
    1.00 ± 0.04 times faster than uv run --no-cache --all-extras pytest -n 4
    2.06 ± 0.09 times faster than uv run --no-cache --all-extras pytest -n 2
    2.88 ± 0.12 times faster than uv run --no-cache --all-extras pytest -n 1
```    
