### PR TITLE
Remove typst markup from md and html rendered outputs

### DIFF
--- a/src/rendercv/renderer/templater/model_processor.py
+++ b/src/rendercv/renderer/templater/model_processor.py
@@ -28,6 +28,8 @@ def process_model(
     Returns:
         Processed model ready for templates.
     """
+    rendercv_model = rendercv_model.model_copy(deep=True)
+
     string_processors: list[Callable[[str], str]] = [
         lambda string: make_keywords_bold(string, rendercv_model.settings.bold_keywords)
     ]


### PR DESCRIPTION
Fixes #563 by deep copying the `RenderCVModel` so that typst markup is not passed down the line.