### PR TITLE
feat(locale): add indonesian locale

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -801,6 +801,100 @@
       "title": "HindiLocale",
       "type": "object"
     },
+    "IndonesiaLocale": {
+      "additionalProperties": false,
+      "properties": {
+        "language": {
+          "const": "indonesia",
+          "default": "indonesia",
+          "description": "The language for your CV. The default value is `indonesia`.",
+          "title": "Language",
+          "type": "string"
+        },
+        "last_updated": {
+          "default": "Terakhir diperbarui",
+          "description": "Translation of \"Last updated in\". The default value is `Terakhir diperbarui`.",
+          "title": "Last Updated",
+          "type": "string"
+        },
+        "month": {
+          "default": "bulan",
+          "description": "Translation of \"month\" (singular). The default value is `bulan`.",
+          "title": "Month",
+          "type": "string"
+        },
+        "months": {
+          "default": "bulan",
+          "description": "Translation of \"months\" (plural). The default value is `bulan`.",
+          "title": "Months",
+          "type": "string"
+        },
+        "year": {
+          "default": "tahun",
+          "description": "Translation of \"year\" (singular). The default value is `tahun`.",
+          "title": "Year",
+          "type": "string"
+        },
+        "years": {
+          "default": "tahun",
+          "description": "Translation of \"years\" (plural). The default value is `tahun`.",
+          "title": "Years",
+          "type": "string"
+        },
+        "present": {
+          "default": "sekarang",
+          "description": "Translation of \"present\" for ongoing dates. The default value is `sekarang`.",
+          "title": "Present",
+          "type": "string"
+        },
+        "month_abbreviations": {
+          "default": [
+            "Jan",
+            "Feb",
+            "Mar",
+            "Apr",
+            "Mei",
+            "Jun",
+            "Jul",
+            "Agu",
+            "Sep",
+            "Okt",
+            "Nov",
+            "Des"
+          ],
+          "description": "Month abbreviations (Jan-Dec).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Month Abbreviations",
+          "type": "array"
+        },
+        "month_names": {
+          "default": [
+            "Januari",
+            "Februari",
+            "Maret",
+            "April",
+            "Mei",
+            "Juni",
+            "Juli",
+            "Agustus",
+            "September",
+            "Oktober",
+            "November",
+            "Desember"
+          ],
+          "description": "Full month names (January-December).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Month Names",
+          "type": "array"
+        }
+      },
+      "title": "IndonesiaLocale",
+      "type": "object"
+    },
     "ItalianLocale": {
       "additionalProperties": false,
       "properties": {
@@ -1148,6 +1242,7 @@
           "french": "#/$defs/FrenchLocale",
           "german": "#/$defs/GermanLocale",
           "hindi": "#/$defs/HindiLocale",
+          "indonesia": "#/$defs/IndonesiaLocale",
           "italian": "#/$defs/ItalianLocale",
           "japanese": "#/$defs/JapaneseLocale",
           "korean": "#/$defs/KoreanLocale",
@@ -1171,6 +1266,9 @@
         },
         {
           "$ref": "#/$defs/HindiLocale"
+        },
+        {
+          "$ref": "#/$defs/IndonesiaLocale"
         },
         {
           "$ref": "#/$defs/ItalianLocale"

--- a/src/rendercv/schema/models/locale/english_locale.py
+++ b/src/rendercv/schema/models/locale/english_locale.py
@@ -107,4 +107,5 @@ class EnglishLocale(BaseModelWithoutExtraKeys):
             "russian": "ru",
             "japanese": "ja",
             "korean": "ko",
+            "indonesia": "id",
         }[self.language]

--- a/src/rendercv/schema/models/locale/other_locales/indonesia.yaml
+++ b/src/rendercv/schema/models/locale/other_locales/indonesia.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=../../../../../../schema.json
+locale:
+  language: indonesia
+  last_updated: Terakhir diperbarui
+  month: bulan
+  months: bulan
+  year: tahun
+  years: tahun
+  present: sekarang
+  month_abbreviations:
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - Mei
+    - Jun
+    - Jul
+    - Agu
+    - Sep
+    - Okt
+    - Nov
+    - Des
+  month_names:
+    - Januari
+    - Februari
+    - Maret
+    - April
+    - Mei
+    - Juni
+    - Juli
+    - Agustus
+    - September
+    - Oktober
+    - November
+    - Desember
+


### PR DESCRIPTION
# Add Indonesian Locale Support

## Summary

This PR adds Indonesian (Bahasa Indonesia) locale support to RenderCV, allowing users to create CVs with Indonesian translations for date formatting, month names, and other locale-specific text.

## Changes Made

### Added
- **New locale file**: `src/rendercv/schema/models/locale/other_locales/indonesia.yaml`
  - Complete Indonesian translations for all locale fields
  - Month abbreviations: Jan, Feb, Mar, Apr, Mei, Jun, Jul, Agu, Sep, Okt, Nov, Des
  - Full month names: Januari, Februari, Maret, April, Mei, Juni, Juli, Agustus, September, Oktober, November, Desember
  - Translations: `last_updated`, `month`, `months`, `year`, `years`, `present`

### Modified
- **`src/rendercv/schema/models/locale/english_locale.py`**
  - Added ISO 639-1 language code mapping: `"indonesia": "id"` to the `language_iso_639_1` method

- **`schema.json`**
  - Updated to include `indonesia` as a valid locale option (auto-generated via `just update-schema`)

## Testing

✅ All tests pass:
- `test_available_locales()` - Verifies locale is discovered and included in available locales
- `test_creates_valid_model_for_all_themes_and_locales[indonesia-*]` - Validates locale works with all 5 themes:
  - classic
  - engineeringclassic
  - engineeringresumes
  - moderncv
  - sb2nov

✅ Manual verification:
- Locale correctly loads from YAML file
- ISO 639-1 code "id" is properly mapped
- All translations are correctly applied
- No linter errors

## Usage

Users can now use Indonesian locale in their CV YAML files:

```yaml
locale:
  language: indonesia
```

Or when creating a new CV:

```bash
rendercv new "Nama Anda" --locale indonesia
```

## Example Translations

- `last_updated`: "Terakhir diperbarui"
- `month` / `months`: "bulan"
- `year` / `years`: "tahun"
- `present`: "sekarang"
- Month names: Januari, Februari, Maret, April, Mei, Juni, Juli, Agustus, September, Oktober, November, Desember

## Related

This follows the same pattern as other locale additions (see v2.4 changelog entry for 11 languages added). The implementation follows the developer guide: [How to Add a Locale](https://docs.rendercv.com/developer_guide/how_to/add_locale/).

## Checklist

- [x] Locale YAML file created with all required fields
- [x] ISO 639-1 code added to `english_locale.py`
- [x] Schema updated (`just update-schema` run)
- [x] All tests pass
- [x] Locale works with all themes
- [x] No linter errors
- [x] Follows existing locale file structure and conventions

