### PR TITLE
fix: support DAY and DAY_IN_TWO_DIGITS in date templates (CURRENT_DAT…

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Ensure bash is installed
+        run: sudo apt-get update && sudo apt-get install -y bash
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/src/rendercv/renderer/templater/date.py
+++ b/src/rendercv/renderer/templater/date.py
@@ -41,6 +41,7 @@ def date_object_to_string(
     month_abbreviations = locale.month_abbreviations
 
     month = int(date.strftime("%m"))
+    day = int(date.strftime("%d"))
     year = int(date.strftime(format="%Y"))
 
     placeholders: dict[str, str] = {
@@ -48,6 +49,8 @@ def date_object_to_string(
         "MONTH_ABBREVIATION": month_abbreviations[month - 1],
         "MONTH": str(month),
         "MONTH_IN_TWO_DIGITS": f"{month:02d}",
+        "DAY": str(day),
+        "DAY_IN_TWO_DIGITS": f"{day:02d}",
         "YEAR": str(year),
         "YEAR_IN_TWO_DIGITS": str(year)[-2:],
     }

--- a/src/rendercv/renderer/templater/footer_and_top_note.py
+++ b/src/rendercv/renderer/templater/footer_and_top_note.py
@@ -53,6 +53,7 @@ def render_top_note_template(
     month_abbreviations = locale.month_abbreviations
 
     month = int(current_date.strftime("%m"))
+    day = int(current_date.strftime("%d"))
     year = int(current_date.strftime(format="%Y"))
 
     placeholders: dict[str, str] = {
@@ -67,6 +68,8 @@ def render_top_note_template(
         "MONTH_ABBREVIATION": month_abbreviations[month - 1],
         "MONTH": str(month),
         "MONTH_IN_TWO_DIGITS": f"{month:02d}",
+        "DAY": str(day),
+        "DAY_IN_TWO_DIGITS": f"{day:02d}",
         "YEAR": str(year),
         "YEAR_IN_TWO_DIGITS": str(year)[-2:],
     }

--- a/tests/renderer/templater/test_date.py
+++ b/tests/renderer/templater/test_date.py
@@ -45,9 +45,19 @@ from rendercv.schema.models.locale.english_locale import EnglishLocale
         (Date(2020, 3, 15), "YEAR-MONTH_IN_TWO_DIGITS", {}, "2020-03"),
         # Test DAY and DAY_IN_TWO_DIGITS
         (Date(2020, 12, 5), "MONTH/DAY/YEAR", {}, "12/5/2020"),
-        (Date(2020, 12, 5), "MONTH_IN_TWO_DIGITS/DAY_IN_TWO_DIGITS/YEAR", {}, "12/05/2020"),
+        (
+            Date(2020, 12, 5),
+            "MONTH_IN_TWO_DIGITS/DAY_IN_TWO_DIGITS/YEAR",
+            {},
+            "12/05/2020",
+        ),
         (Date(2020, 1, 9), "MONTH/DAY/YEAR", {}, "1/9/2020"),
-        (Date(2020, 1, 9), "MONTH_IN_TWO_DIGITS/DAY_IN_TWO_DIGITS/YEAR", {}, "01/09/2020"),
+        (
+            Date(2020, 1, 9),
+            "MONTH_IN_TWO_DIGITS/DAY_IN_TWO_DIGITS/YEAR",
+            {},
+            "01/09/2020",
+        ),
         # Custom month abbreviations
         (
             Date(2020, 1, 1),

--- a/tests/renderer/templater/test_date.py
+++ b/tests/renderer/templater/test_date.py
@@ -43,6 +43,11 @@ from rendercv.schema.models.locale.english_locale import EnglishLocale
             "March (Mar) 3, 2020",
         ),
         (Date(2020, 3, 15), "YEAR-MONTH_IN_TWO_DIGITS", {}, "2020-03"),
+        # Test DAY and DAY_IN_TWO_DIGITS
+        (Date(2020, 12, 5), "MONTH/DAY/YEAR", {}, "12/5/2020"),
+        (Date(2020, 12, 5), "MONTH_IN_TWO_DIGITS/DAY_IN_TWO_DIGITS/YEAR", {}, "12/05/2020"),
+        (Date(2020, 1, 9), "MONTH/DAY/YEAR", {}, "1/9/2020"),
+        (Date(2020, 1, 9), "MONTH_IN_TWO_DIGITS/DAY_IN_TWO_DIGITS/YEAR", {}, "01/09/2020"),
         # Custom month abbreviations
         (
             Date(2020, 1, 1),


### PR DESCRIPTION
Here’s what was changed in your code to fix the CURRENT_DATE formatting issue:

In src/rendercv/renderer/templater/date.py:

Added support for DAY and DAY_IN_TWO_DIGITS placeholders in the date_object_to_string function. Now, if your template uses DAY or DAY_IN_TWO_DIGITS, they will be replaced with the correct day value.
In src/rendercv/renderer/templater/footer_and_top_note.py:

Updated the render_top_note_template function to include DAY and DAY_IN_TWO_DIGITS in the placeholders dictionary, so they are available for top_note and similar templates.
In tests/renderer/templater/test_date.py:

Added new tests to verify that DAY and DAY_IN_TWO_DIGITS work as expected in date templates.
These changes ensure that templates like MONTH/DAY/YEAR will now correctly render the day component in your output.