### PR TITLE
Fix Unicode corruption in sample YAML name generation

### DIFF
--- a/src/rendercv/schema/sample_generator.py
+++ b/src/rendercv/schema/sample_generator.py
@@ -70,7 +70,6 @@ def create_sample_rendercv_pydantic_model(
     sample_content_dictionary = read_yaml(sample_content)["cv"]
     cv = Cv(**sample_content_dictionary)
 
-    name = name.encode().decode("unicode-escape")
     cv.name = name
 
     design = built_in_design_adapter.validate_python({"theme": theme})

--- a/tests/schema/test_sample_generator.py
+++ b/tests/schema/test_sample_generator.py
@@ -37,6 +37,11 @@ class TestCreateSampleRendercvPydanticModel:
                 name="John Doe", theme="classic", locale="invalid"
             )
 
+    def test_creates_model_with_unicode_name(self):
+        name = "Matías"
+        data_model = create_sample_rendercv_pydantic_model(name=name)
+        assert data_model.cv.name == name
+
 
 class TestCreateSampleYamlInputFile:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Fixes a bug that mangled non-ASCII characters in the name field of the sample YAML produced by rendercv new (for example, "Matías" became "MatÃ­as").

## Root cause
An unnecessary encode/decode using "unicode-escape" in the sample generator caused UTF-8 bytes to be mis-decoded. The problematic code was in sample_generator.py.

## What I changed
Removed the incorrect transformation:

```py
name = name.encode().decode("unicode-escape")
```

And assigned the provided name directly to the model.

## Tests / Verification
Added unit test: test_creates_model_with_unicode_name

Ran the sample-generator tests to ensure no regressions.

## Impact
### Backward-compatible bugfix.

Fixes the rendercv new YAML output.

Fixes any generated filenames using the name placeholder.

## How to reproduce / validate locally
Run rendercv new and provide a name with accents (e.g., "Matías", "José", etc).

Check the generated .yaml file to ensure the name is rendered correctly.

Run the test suite: `just test`