### PR TITLE
fix the filename in pdf header rendercv/rendercv#557

### DIFF
--- a/src/rendercv/renderer/templater/templates/typst/Preamble.j2.typ
+++ b/src/rendercv/renderer/templater/templates/typst/Preamble.j2.typ
@@ -3,7 +3,7 @@
 
 // Apply the rendercv template with custom configuration
 #show: rendercv.with(
-  name: "{{ cv.name }}",
+  name: "{{ cv.plain_name }}",
   footer: {{ cv.footer }},
   top-note: [ {{ cv.top_note }} ],
   locale-catalog-language: "{{ locale.language_iso_639_1 }}",


### PR DESCRIPTION
**Issue**: rendercv/rendercv#557

The case has been happened due to the usage of `name` in the rendercv_model instead of using `plain_name`. The fixation is done in the `src/rendercv/renderer/templater/templates/typst/Preamble.j2.typ` file by using the right attribute.