### PR TITLE
feat(locale): add Hebrew locale (and generic RTL issues)

### DIFF
--- a/docs/developer_guide/how_to/add_locale.md
+++ b/docs/developer_guide/how_to/add_locale.md
@@ -48,7 +48,7 @@
 
 3. Add ISO 639-1 language code to `english_locale.py`
 
-    Edit `src/rendercv/schema/models/locale/english_locale.py` line 95-108:
+    Edit `src/rendercv/schema/models/locale/english_locale.py` line 97-114:
 
     ```python
     return {

--- a/schema.json
+++ b/schema.json
@@ -801,6 +801,100 @@
       "title": "GermanLocale",
       "type": "object"
     },
+    "HebrewLocale": {
+      "additionalProperties": false,
+      "properties": {
+        "language": {
+          "const": "hebrew",
+          "default": "hebrew",
+          "description": "The language for your CV. The default is `hebrew`.",
+          "title": "Language",
+          "type": "string"
+        },
+        "last_updated": {
+          "default": "עודכן לאחרונה",
+          "description": "Translation of \"Last updated in\". The default value is `עודכן לאחרונה`.",
+          "title": "Last Updated",
+          "type": "string"
+        },
+        "month": {
+          "default": "חודש",
+          "description": "Translation of \"month\" (singular). The default value is `חודש`.",
+          "title": "Month",
+          "type": "string"
+        },
+        "months": {
+          "default": "חודשים",
+          "description": "Translation of \"months\" (plural). The default value is `חודשים`.",
+          "title": "Months",
+          "type": "string"
+        },
+        "year": {
+          "default": "שנה",
+          "description": "Translation of \"year\" (singular). The default value is `שנה`.",
+          "title": "Year",
+          "type": "string"
+        },
+        "years": {
+          "default": "שנים",
+          "description": "Translation of \"years\" (plural). The default value is `שנים`.",
+          "title": "Years",
+          "type": "string"
+        },
+        "present": {
+          "default": "הווה",
+          "description": "Translation of \"present\" for ongoing dates. The default value is `הווה`.",
+          "title": "Present",
+          "type": "string"
+        },
+        "month_abbreviations": {
+          "default": [
+            "ינו'",
+            "פבר'",
+            "מרץ",
+            "אפר'",
+            "מאי",
+            "יוני",
+            "יולי",
+            "אוג'",
+            "ספט'",
+            "אוק'",
+            "נוב'",
+            "דצמ'"
+          ],
+          "description": "Month abbreviations (Jan-Dec).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Month Abbreviations",
+          "type": "array"
+        },
+        "month_names": {
+          "default": [
+            "ינואר",
+            "פברואר",
+            "מרץ",
+            "אפריל",
+            "מאי",
+            "יוני",
+            "יולי",
+            "אוגוסט",
+            "ספטמבר",
+            "אוקטובר",
+            "נובמבר",
+            "דצמבר"
+          ],
+          "description": "Full month names (January-December).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Month Names",
+          "type": "array"
+        }
+      },
+      "title": "HebrewLocale",
+      "type": "object"
+    },
     "HindiLocale": {
       "additionalProperties": false,
       "properties": {
@@ -1336,6 +1430,7 @@
           "english": "#/$defs/EnglishLocale",
           "french": "#/$defs/FrenchLocale",
           "german": "#/$defs/GermanLocale",
+          "hebrew": "#/$defs/HebrewLocale",
           "hindi": "#/$defs/HindiLocale",
           "indonesian": "#/$defs/IndonesianLocale",
           "italian": "#/$defs/ItalianLocale",
@@ -1361,6 +1456,9 @@
         },
         {
           "$ref": "#/$defs/GermanLocale"
+        },
+        {
+          "$ref": "#/$defs/HebrewLocale"
         },
         {
           "$ref": "#/$defs/HindiLocale"

--- a/src/rendercv/schema/models/locale/english_locale.py
+++ b/src/rendercv/schema/models/locale/english_locale.py
@@ -99,6 +99,7 @@ class EnglishLocale(BaseModelWithoutExtraKeys):
             "english": "en",
             "french": "fr",
             "german": "de",
+            "hebrew": "he",
             "hindi": "hi",
             "italian": "it",
             "indonesian": "id",

--- a/src/rendercv/schema/models/locale/other_locales/hebrew.yaml
+++ b/src/rendercv/schema/models/locale/other_locales/hebrew.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=../../../../../../schema.json
+locale:
+  language: hebrew
+  last_updated: "עודכן לאחרונה"
+  month: "חודש"
+  months: "חודשים"
+  year: "שנה"
+  years: "שנים"
+  present: "הווה"
+  month_abbreviations:
+    - ינו'
+    - פבר'
+    - מרץ
+    - אפר'
+    - מאי
+    - יוני
+    - יולי
+    - אוג'
+    - ספט'
+    - אוק'
+    - נוב'
+    - דצמ'
+  month_names:
+    - ינואר
+    - פברואר
+    - מרץ
+    - אפריל
+    - מאי
+    - יוני
+    - יולי
+    - אוגוסט
+    - ספטמבר
+    - אוקטובר
+    - נובמבר
+    - דצמבר


### PR DESCRIPTION
(Related to #452 and blocked by #591)

Added Hebrew as a valid locale. Also took the liberty to update line numbers in the docs.

There are still quite a few RTL issues.

PDF:
 - Sections' headers are rendered correctly, however the contents is still aligned to the left:
 
<img width="952" height="420" alt="image" src="https://github.com/user-attachments/assets/c6043750-6ae8-4acb-aa65-ab1aa9777ae4" />

<hr>

HTML:
 - The rendered html is missing `<body dir="rtl">`. Can be manually added by the user but would be nice if could be done automatically. The fix for this might required adding a new "rtl" boolean to locale in the schema/model.

<hr>

There are possibly more issues that I haven't found or noticed yet.

As the fixes would probably be required to render other RTL languages we can use this PR as a larger initiative.


This feels like a regression from 2.3, as the CV is rendered perfectly on the web app by simply using

```yaml
locale:
  language: he
```

<img width="780" height="291" alt="image" src="https://github.com/user-attachments/assets/7363a5ad-dd43-4b9f-98db-230926771f35" />
