### PR TITLE
Fix: Prevent local file access via `photo` field using magic bytes

### DIFF
--- a/src/rendercv/schema/models/cv/cv.py
+++ b/src/rendercv/schema/models/cv/cv.py
@@ -7,7 +7,7 @@ import pydantic_extra_types.phone_numbers as pydantic_phone_numbers
 from rendercv.exception import RenderCVInternalError
 
 from ..base import BaseModelWithExtraKeys
-from ..path import ExistingPathRelativeToInput
+from ..path import ExistingImagePathRelativeToInput
 from .custom_connection import CustomConnection
 from .section import BaseRenderCVSection, Section, get_rendercv_sections
 from .social_network import SocialNetwork
@@ -41,9 +41,9 @@ class Cv(BaseModelWithExtraKeys):
             ["john.doe.1@example.com", "john.doe.2@example.com"],
         ],
     )
-    photo: ExistingPathRelativeToInput | None = pydantic.Field(
+    photo: ExistingImagePathRelativeToInput | None = pydantic.Field(
         default=None,
-        description="Photo file path, relative to the YAML file.",
+        description="Photo file path, relative to the YAML file. Must be a valid image file (PNG, JPEG, GIF, BMP, WebP, TIFF).",
         examples=["photo.jpg", "images/profile.png"],
     )
     phone: (

--- a/src/rendercv/schema/models/path.py
+++ b/src/rendercv/schema/models/path.py
@@ -10,14 +10,14 @@ from .validation_context import get_input_file_path
 # Magic byte signatures for common image formats
 # Format: (magic_bytes, offset, format_name)
 IMAGE_SIGNATURES: list[tuple[bytes, int, str]] = [
-    (b'\x89PNG\r\n\x1a\n', 0, 'PNG'),
-    (b'\xff\xd8\xff', 0, 'JPEG'),
-    (b'GIF87a', 0, 'GIF'),
-    (b'GIF89a', 0, 'GIF'),
-    (b'BM', 0, 'BMP'),
-    (b'RIFF', 0, 'WebP'),  # WebP starts with RIFF, followed by file size, then WEBP
-    (b'II*\x00', 0, 'TIFF'),  # Little-endian TIFF
-    (b'MM\x00*', 0, 'TIFF'),  # Big-endian TIFF
+    (b"\x89PNG\r\n\x1a\n", 0, "PNG"),
+    (b"\xff\xd8\xff", 0, "JPEG"),
+    (b"GIF87a", 0, "GIF"),
+    (b"GIF89a", 0, "GIF"),
+    (b"BM", 0, "BMP"),
+    (b"RIFF", 0, "WebP"),  # WebP starts with RIFF, followed by file size, then WEBP
+    (b"II*\x00", 0, "TIFF"),  # Little-endian TIFF
+    (b"MM\x00*", 0, "TIFF"),  # Big-endian TIFF
 ]
 
 
@@ -36,14 +36,14 @@ def is_valid_image_file(path: pathlib.Path) -> bool:
         True if the file has valid image magic bytes, False otherwise.
     """
     try:
-        with path.open('rb') as f: # issue should be fixed
+        with path.open("rb") as f:
             # Read enough bytes to check all signatures (max 12 bytes needed for WebP)
             header = f.read(12)
 
         for magic, offset, _ in IMAGE_SIGNATURES:
-            if header[offset:offset + len(magic)] == magic:
+            if header[offset : offset + len(magic)] == magic:
                 # Special case for WebP: must also have 'WEBP' at offset 8
-                if magic == b'RIFF' and header[8:12] != b'WEBP':
+                if magic == b"RIFF" and header[8:12] != b"WEBP":
                     continue
                 return True
 

--- a/src/rendercv/schema/models/path.py
+++ b/src/rendercv/schema/models/path.py
@@ -36,7 +36,7 @@ def is_valid_image_file(path: pathlib.Path) -> bool:
         True if the file has valid image magic bytes, False otherwise.
     """
     try:
-        with open(path, 'rb') as f:
+        with Path.open(path, 'rb') as f:
             # Read enough bytes to check all signatures (max 12 bytes needed for WebP)
             header = f.read(12)
 

--- a/src/rendercv/schema/models/path.py
+++ b/src/rendercv/schema/models/path.py
@@ -36,7 +36,7 @@ def is_valid_image_file(path: pathlib.Path) -> bool:
         True if the file has valid image magic bytes, False otherwise.
     """
     try:
-        with Path.open(path, 'rb') as f:
+        with path.open(path, 'rb') as f:
             # Read enough bytes to check all signatures (max 12 bytes needed for WebP)
             header = f.read(12)
 

--- a/src/rendercv/schema/models/path.py
+++ b/src/rendercv/schema/models/path.py
@@ -48,7 +48,7 @@ def is_valid_image_file(path: pathlib.Path) -> bool:
                 return True
 
         return False
-    except (OSError, IOError):
+    except OSError:
         return False
 
 

--- a/src/rendercv/schema/models/path.py
+++ b/src/rendercv/schema/models/path.py
@@ -36,7 +36,7 @@ def is_valid_image_file(path: pathlib.Path) -> bool:
         True if the file has valid image magic bytes, False otherwise.
     """
     try:
-        with path.open('rb') as f:
+        with path.open('rb') as f: # issue should be fixed
             # Read enough bytes to check all signatures (max 12 bytes needed for WebP)
             header = f.read(12)
 

--- a/src/rendercv/schema/models/path.py
+++ b/src/rendercv/schema/models/path.py
@@ -36,7 +36,7 @@ def is_valid_image_file(path: pathlib.Path) -> bool:
         True if the file has valid image magic bytes, False otherwise.
     """
     try:
-        with path.open(path, 'rb') as f:
+        with path.open('rb') as f:
             # Read enough bytes to check all signatures (max 12 bytes needed for WebP)
             header = f.read(12)
 

--- a/src/rendercv/schema/models/path.py
+++ b/src/rendercv/schema/models/path.py
@@ -7,6 +7,50 @@ import pydantic_core
 from ..pydantic_error_handling import CustomPydanticErrorTypes
 from .validation_context import get_input_file_path
 
+# Magic byte signatures for common image formats
+# Format: (magic_bytes, offset, format_name)
+IMAGE_SIGNATURES: list[tuple[bytes, int, str]] = [
+    (b'\x89PNG\r\n\x1a\n', 0, 'PNG'),
+    (b'\xff\xd8\xff', 0, 'JPEG'),
+    (b'GIF87a', 0, 'GIF'),
+    (b'GIF89a', 0, 'GIF'),
+    (b'BM', 0, 'BMP'),
+    (b'RIFF', 0, 'WebP'),  # WebP starts with RIFF, followed by file size, then WEBP
+    (b'II*\x00', 0, 'TIFF'),  # Little-endian TIFF
+    (b'MM\x00*', 0, 'TIFF'),  # Big-endian TIFF
+]
+
+
+def is_valid_image_file(path: pathlib.Path) -> bool:
+    """Check if a file is a valid image by examining magic bytes.
+
+    Why:
+        Magic byte validation prevents arbitrary file access via photo fields.
+        Checking file signatures is more reliable than extension-based checks
+        and prevents attackers from referencing non-image files.
+
+    Args:
+        path: Path to the file to validate.
+
+    Returns:
+        True if the file has valid image magic bytes, False otherwise.
+    """
+    try:
+        with open(path, 'rb') as f:
+            # Read enough bytes to check all signatures (max 12 bytes needed for WebP)
+            header = f.read(12)
+
+        for magic, offset, _ in IMAGE_SIGNATURES:
+            if header[offset:offset + len(magic)] == magic:
+                # Special case for WebP: must also have 'WEBP' at offset 8
+                if magic == b'RIFF' and header[8:12] != b'WEBP':
+                    continue
+                return True
+
+        return False
+    except (OSError, IOError):
+        return False
+
 
 def resolve_relative_path(
     path: pathlib.Path, info: pydantic.ValidationInfo, *, must_exist: bool = True
@@ -56,6 +100,47 @@ def resolve_relative_path(
     return path
 
 
+def validate_image_path(
+    path: pathlib.Path, info: pydantic.ValidationInfo
+) -> pathlib.Path:
+    """Validate that a path points to an existing image file.
+
+    Why:
+        Ensures photo fields reference actual image files, preventing
+        arbitrary file access via crafted YAML inputs. Combines path
+        resolution with image format validation.
+
+    Args:
+        path: Path to validate (may be relative or absolute).
+        info: Validation context containing input file path.
+
+    Returns:
+        Resolved absolute path if valid image.
+
+    Raises:
+        PydanticCustomError: If path doesn't exist or isn't a valid image.
+    """
+    # First resolve the path and check existence
+    resolved_path = resolve_relative_path(path, info, must_exist=True)
+
+    # Then validate it's actually an image file
+    if resolved_path and not is_valid_image_file(resolved_path):
+        input_file_path = get_input_file_path(info)
+        relative_to = input_file_path.parent if input_file_path else pathlib.Path.cwd()
+        try:
+            display_path = resolved_path.relative_to(relative_to)
+        except ValueError:
+            display_path = resolved_path
+        raise pydantic_core.PydanticCustomError(
+            CustomPydanticErrorTypes.other.value,
+            "The file `{file_path}` is not a valid image file. "
+            "Supported formats: PNG, JPEG, GIF, BMP, WebP, TIFF.",
+            {"file_path": display_path},
+        )
+
+    return resolved_path
+
+
 def serialize_path(path: pathlib.Path) -> str:
     return str(path.relative_to(pathlib.Path.cwd()))
 
@@ -65,6 +150,11 @@ type ExistingPathRelativeToInput = Annotated[
     pydantic.AfterValidator(
         lambda path, info: resolve_relative_path(path, info, must_exist=True)
     ),
+]
+
+type ExistingImagePathRelativeToInput = Annotated[
+    pathlib.Path,
+    pydantic.AfterValidator(validate_image_path),
 ]
 
 type PlannedPathRelativeToInput = Annotated[


### PR DESCRIPTION
# Summary

This PR addresses the local file access vulnerability by implementing file type validation for the `cv.photo` field. Instead of restricting paths ([597](https://github.com/rendercv/rendercv/pull/597)) to the input directory (which limits user flexibility), this approach validates that the referenced file is actually a valid image by checking its magic bytes.

Changes
`src/rendercv/schema/models/path.py`

Added:

+ `IMAGE_SIGNATURES` constant: Magic byte signatures for `PNG, JPEG, GIF, BMP, WebP`, and `TIFF` formats.

+ `is_valid_image_file(path)` function: Validates a file is an image by reading and checking its first 12 bytes against known signatures.

+ `validate_image_path(path, info)` function: Combines path resolution with image format validation.

+ `ExistingImagePathRelativeToInput` type alias: New Pydantic-annotated type for image-specific path validation.

src/rendercv/schema/models/cv/cv.py
**Modified**:
+ Changed `photo` field type from `ExistingPathRelativeToInput` to `ExistingImagePathRelativeToInput`
+ Updated field description to document supported image formats.

## Related Issues

+ Fixes > https://github.com/rendercv/rendercv/issues/598
