### PR TITLE
Fix: Update user guide CLI reference to remove incorrect override option #595

### DIFF
--- a/docs/user_guide/cli_reference.md
+++ b/docs/user_guide/cli_reference.md
@@ -137,12 +137,12 @@ rendercv render John_Doe_CV.yaml --pdf-path ~/Desktop/MyCV.pdf
 
 **Override any YAML value:**
 
-Use dot notation to change specific fields. This overrides values in the YAML without editing the file.
+Use dot notation to change specific fields. This overrides values in the YAML without editing the file. Overrides are supported for fields within the `CV.yaml` and `settings.yaml` files.
 
 ```bash
 rendercv render CV.yaml --cv.phone "+1-555-555-5555"
 rendercv render CV.yaml --cv.sections.education.0.institution "MIT"
-rendercv render CV.yaml --design.theme "moderncv"
+rendercv render CV.yaml --settings.current_date "2025-12-01"
 ```
 
 ## `rendercv create-theme`

--- a/schema.json
+++ b/schema.json
@@ -155,7 +155,7 @@
       "type": "object"
     },
     "Cv": {
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "name": {
           "anyOf": [
@@ -4986,6 +4986,7 @@
           "description": "Vertical space between text-based entries. It can be specified with units (cm, in, pt, mm, ex, em). For example, `0.1cm`. The default value is `0.3em`."
         },
         "show_time_spans_in": {
+          "default": [],
           "description": "Section titles where time spans (e.g., '2 years 3 months') should be displayed. The default value is `[]`.",
           "items": {
             "type": "string"
@@ -5017,6 +5018,7 @@
           "description": "Vertical space between text-based entries. It can be specified with units (cm, in, pt, mm, ex, em). For example, `0.1cm`. The default value is `0.15cm`."
         },
         "show_time_spans_in": {
+          "default": [],
           "description": "Section titles where time spans (e.g., '2 years 3 months') should be displayed. The default value is `[]`.",
           "items": {
             "type": "string"
@@ -5048,6 +5050,7 @@
           "description": "Vertical space between text-based entries. It can be specified with units (cm, in, pt, mm, ex, em). For example, `0.1cm`. The default value is `0.3em`."
         },
         "show_time_spans_in": {
+          "default": [],
           "description": "Section titles where time spans (e.g., '2 years 3 months') should be displayed. The default value is `[]`.",
           "items": {
             "type": "string"
@@ -5079,6 +5082,7 @@
           "description": "Vertical space between text-based entries. It can be specified with units (cm, in, pt, mm, ex, em). For example, `0.1cm`. The default value is `0.3em`."
         },
         "show_time_spans_in": {
+          "default": [],
           "description": "Section titles where time spans (e.g., '2 years 3 months') should be displayed. The default value is `[]`.",
           "items": {
             "type": "string"
@@ -5744,7 +5748,7 @@
       "type": "string"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "cv": {
       "$ref": "#/$defs/Cv",

--- a/src/rendercv/schema/models/cv/cv.py
+++ b/src/rendercv/schema/models/cv/cv.py
@@ -6,7 +6,7 @@ import pydantic_extra_types.phone_numbers as pydantic_phone_numbers
 
 from rendercv.exception import RenderCVInternalError
 
-from ..base import BaseModelWithExtraKeys
+from ..base import BaseModelWithoutExtraKeys
 from ..path import ExistingPathRelativeToInput
 from .custom_connection import CustomConnection
 from .section import BaseRenderCVSection, Section, get_rendercv_sections
@@ -20,7 +20,7 @@ phone_validator = pydantic.TypeAdapter(pydantic_phone_numbers.PhoneNumber)
 phones_validator = pydantic.TypeAdapter(list[pydantic_phone_numbers.PhoneNumber])
 
 
-class Cv(BaseModelWithExtraKeys):
+class Cv(BaseModelWithoutExtraKeys):
     name: str | None = pydantic.Field(
         default=None,
         examples=["John Doe", "Jane Smith"],

--- a/src/rendercv/schema/models/rendercv_model.py
+++ b/src/rendercv/schema/models/rendercv_model.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pydantic
 
-from .base import BaseModelWithExtraKeys
+from .base import BaseModelWithoutExtraKeys
 from .cv.cv import Cv
 from .design.classic_theme import ClassicTheme
 from .design.design import Design
@@ -11,7 +11,7 @@ from .settings.settings import Settings
 from .validation_context import get_input_file_path
 
 
-class RenderCVModel(BaseModelWithExtraKeys):
+class RenderCVModel(BaseModelWithoutExtraKeys):
     # Technically, `cv` is a required field, but we don't pass it to the JSON Schema
     # so that the same schema can be used for standalone design, locale, and settings
     # files.


### PR DESCRIPTION
The existing documentation for field overrides is incorrect, and contains a command that claims the user is able to use dot notation to override YAML values in the `design` which is not supported:

> `rendercv render CV.yaml --design.theme "moderncv"`

(See "Override any YAML value" on [this page](https://docs.rendercv.com/user_guide/cli_reference/))

The new documentation was added in commit [33d15d0](https://github.com/rendercv/rendercv/commit/33d15d0f910f9688bd20ca58356e46fcd2f6cf18#diff-7beaa42f1809eaf10e957c3502bcc6be8e5689b17b07eb035006a0ea8ca80f18).

Only fields that exist within `CV.yaml` or `settings.yaml` can be overridden using dot notation, as the [method responsible for handling these overrides](https://github.com/rendercv/rendercv/blob/main/src/rendercv/schema/rendercv_model_builder.py#L33) is not reading the contents of the `design.yaml` file, and only has access to the file location reference in the settings.

This commit updates the documentation to reflect this behavior.

I tested the `rendercv render CV.yaml --design.theme "moderncv"` command to confirm it was unsupported and also dug through the code to localize the issue while investigating #595.

Documentation validated visually via `just serve-docs`.