### PR TITLE
updated clean_url function to properly remove "www" from the url

### DIFF
--- a/src/rendercv/renderer/templater/string_processor.py
+++ b/src/rendercv/renderer/templater/string_processor.py
@@ -140,7 +140,7 @@ def clean_url(url: str | pydantic.HttpUrl) -> str:
     Returns:
         Clean URL string.
     """
-    url = str(url).replace("https://", "").replace("http://", "")
+    url = str(url).replace("https://", "").replace("http://", "").replace("www.", "")
     if url.endswith("/"):
         url = url[:-1]
 

--- a/tests/renderer/templater/test_string_processor.py
+++ b/tests/renderer/templater/test_string_processor.py
@@ -46,7 +46,7 @@ def test_substitute_placeholders(string, placeholders, expected_string):
         ("https://example.com/", "example.com"),
         ("https://example.com/test", "example.com/test"),
         ("https://example.com/test/", "example.com/test"),
-        ("https://www.example.com/test/", "www.example.com/test"),
+        ("https://www.example.com/test/", "example.com/test"),
     ],
 )
 def test_clean_url(url, expected_clean_url):


### PR DESCRIPTION
clean_url() docstring said it strips www. from urls, but the implementation didn't actually do that.

Added the missing .replace("www.", "") call so the function matches what it claims to do. 

Updated the test expectation too since it was checking for the old broken behavior.