### PR TITLE
make version check non-blocking

### DIFF
--- a/src/rendercv/cli/app.py
+++ b/src/rendercv/cli/app.py
@@ -2,6 +2,8 @@ import importlib
 import json
 import pathlib
 import ssl
+import threading
+import time
 import urllib.request
 from typing import Annotated
 
@@ -17,6 +19,9 @@ app = typer.Typer(
     invoke_without_command=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
+
+_VERSION_CACHE_FILE = pathlib.Path.home() / ".cache" / "rendercv" / "version_check.json"
+_VERSION_CACHE_TTL_SECONDS = 86400  # 24 hours
 
 
 @app.callback()
@@ -44,30 +49,65 @@ def warn_if_new_version_is_available() -> None:
 
     Why:
         Users should be notified of updates for bug fixes and features.
-        Non-blocking check on startup ensures users stay informed without
-        interrupting workflow if check fails.
+        Uses cached results with 24-hour TTL to avoid blocking network requests
+        on every CLI invocation. Background thread refreshes cache when stale.
     """
+    cached_latest = _read_version_cache()
+
+    if cached_latest is not None:
+        current = packaging.version.Version(__version__)
+        if current < cached_latest:
+            print(
+                "\n[bold yellow]A new version of RenderCV is available! You are using"
+                f" v{__version__}, and the latest version is v{cached_latest}.[/bold"
+                " yellow]\n"
+            )
+    else:
+        thread = threading.Thread(target=_fetch_and_cache_latest_version, daemon=True)
+        thread.start()
+
+
+def _read_version_cache() -> packaging.version.Version | None:
+    """Read cached version if fresh (within TTL), else None."""
+    try:
+        if not _VERSION_CACHE_FILE.exists():
+            return None
+
+        cache_data = json.loads(_VERSION_CACHE_FILE.read_text(encoding="utf-8"))
+        cached_time = cache_data.get("timestamp", 0)
+
+        if time.time() - cached_time > _VERSION_CACHE_TTL_SECONDS:
+            return None
+
+        version_str = cache_data.get("latest_version")
+        if version_str:
+            return packaging.version.Version(version_str)
+    except Exception:
+        pass
+
+    return None
+
+
+def _fetch_and_cache_latest_version() -> None:
+    """Fetch latest version from PyPI and update cache. Silently fails on error."""
     url = "https://pypi.org/pypi/rendercv/json"
     try:
         with urllib.request.urlopen(
-            url, context=ssl._create_unverified_context()
+            url, context=ssl._create_unverified_context(), timeout=5
         ) as response:
             data = response.read()
             encoding = response.info().get_content_charset("utf-8")
             json_data = json.loads(data.decode(encoding))
             version_string = json_data["info"]["version"]
-            latest_version = packaging.version.Version(version_string)
-    except Exception:
-        latest_version = None
 
-    if latest_version is not None:
-        version = packaging.version.Version(__version__)
-        if version < latest_version:
-            print(
-                "\n[bold yellow]A new version of RenderCV is available! You are using"
-                f" v{__version__}, and the latest version is v{latest_version}.[/bold"
-                " yellow]\n"
-            )
+        _VERSION_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        cache_data = {
+            "latest_version": version_string,
+            "timestamp": time.time(),
+        }
+        _VERSION_CACHE_FILE.write_text(json.dumps(cache_data), encoding="utf-8")
+    except Exception:
+        pass
 
 
 # Auto import all commands so that they are registered with the app:

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -1,12 +1,18 @@
 import json
 import pathlib
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from rendercv import __version__
-from rendercv.cli.app import app, warn_if_new_version_is_available
+from rendercv.cli.app import (
+    _fetch_and_cache_latest_version,
+    _read_version_cache,
+    app,
+    warn_if_new_version_is_available,
+)
 
 
 def test_all_commands_are_registered():
@@ -50,6 +56,14 @@ class TestCliCommandNoArgs:
 
 
 class TestWarnIfNewVersionIsAvailable:
+    @pytest.fixture(autouse=True)
+    def clean_cache(self, tmp_path, monkeypatch):
+        cache_file = tmp_path / "version_check.json"
+        monkeypatch.setattr("rendercv.cli.app._VERSION_CACHE_FILE", cache_file)
+        yield cache_file
+        if cache_file.exists():
+            cache_file.unlink()
+
     @pytest.mark.parametrize(
         ("version", "should_warn"),
         [
@@ -58,17 +72,12 @@ class TestWarnIfNewVersionIsAvailable:
             (__version__, False),
         ],
     )
-    @patch("urllib.request.urlopen")
-    def test_warns_when_newer_version_available(
-        self, mock_urlopen, version, should_warn, capsys
+    def test_warns_when_cached_version_is_newer(
+        self, clean_cache, version, should_warn, capsys
     ):
-        mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps(
-            {"info": {"version": version}}
-        ).encode("utf-8")
-        mock_response.info.return_value.get_content_charset.return_value = "utf-8"
-        mock_response.__enter__.return_value = mock_response
-        mock_urlopen.return_value = mock_response
+        cache_data = {"latest_version": version, "timestamp": time.time()}
+        clean_cache.parent.mkdir(parents=True, exist_ok=True)
+        clean_cache.write_text(json.dumps(cache_data), encoding="utf-8")
 
         warn_if_new_version_is_available()
 
@@ -78,11 +87,67 @@ class TestWarnIfNewVersionIsAvailable:
         else:
             assert "new version" not in captured.out.lower()
 
+    def test_spawns_background_thread_on_cache_miss(self):
+        with patch("rendercv.cli.app.threading.Thread") as mock_thread:
+            mock_thread_instance = MagicMock()
+            mock_thread.return_value = mock_thread_instance
+
+            warn_if_new_version_is_available()
+
+            mock_thread.assert_called_once()
+            assert mock_thread.call_args.kwargs["daemon"] is True
+            mock_thread_instance.start.assert_called_once()
+
+    def test_spawns_background_thread_on_stale_cache(self, clean_cache):
+        stale_time = time.time() - 86401
+        cache_data = {"latest_version": "99.0.0", "timestamp": stale_time}
+        clean_cache.parent.mkdir(parents=True, exist_ok=True)
+        clean_cache.write_text(json.dumps(cache_data), encoding="utf-8")
+
+        with patch("rendercv.cli.app.threading.Thread") as mock_thread:
+            mock_thread_instance = MagicMock()
+            mock_thread.return_value = mock_thread_instance
+
+            warn_if_new_version_is_available()
+
+            mock_thread.assert_called_once()
+
     @patch("urllib.request.urlopen")
-    def test_handles_network_errors_gracefully(self, mock_urlopen, capsys):
+    def test_fetch_and_cache_writes_cache_file(self, mock_urlopen, clean_cache):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(
+            {"info": {"version": "99.0.0"}}
+        ).encode("utf-8")
+        mock_response.info.return_value.get_content_charset.return_value = "utf-8"
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+
+        _fetch_and_cache_latest_version()
+
+        assert clean_cache.exists()
+        cache_data = json.loads(clean_cache.read_text(encoding="utf-8"))
+        assert cache_data["latest_version"] == "99.0.0"
+        assert "timestamp" in cache_data
+
+    @patch("urllib.request.urlopen")
+    def test_handles_network_errors_gracefully(self, mock_urlopen, clean_cache, capsys):
         mock_urlopen.side_effect = Exception("Network error")
 
-        warn_if_new_version_is_available()
+        _fetch_and_cache_latest_version()
 
+        assert not clean_cache.exists()
         captured = capsys.readouterr()
         assert "new version" not in captured.out.lower()
+
+    def test_read_version_cache_returns_none_for_missing_file(self):
+        result = _read_version_cache()
+        assert result is None
+
+    def test_read_version_cache_returns_none_for_stale_cache(self, clean_cache):
+        stale_time = time.time() - 86401
+        cache_data = {"latest_version": "99.0.0", "timestamp": stale_time}
+        clean_cache.parent.mkdir(parents=True, exist_ok=True)
+        clean_cache.write_text(json.dumps(cache_data), encoding="utf-8")
+
+        result = _read_version_cache()
+        assert result is None


### PR DESCRIPTION
The PyPI version check was blocking every CLI invocation, adding 100-500ms latency even for simple commands like `--help`.

Now it uses a 24-hour cached result and fetches updates in a background thread, so the CLI feels snappy again.

- Cache stored at `~/.cache/rendercv/version_check.json`
- Background thread refreshes when cache is stale
- Still shows update warnings, just on the next run after cache updates