### PR TITLE
Allow translation of "in" preposition in education section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,8 @@ bin/
 
 # Coverage:
 coverage.md
+
+# custom cv files are excluded, but the ones in examples are included
+*_CV.yaml
+!/examples/*_CV.yaml
+

--- a/schema.json
+++ b/schema.json
@@ -155,7 +155,7 @@
       "type": "object"
     },
     "Cv": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "name": {
           "anyOf": [
@@ -343,6 +343,12 @@
           "title": "Last Updated",
           "type": "string"
         },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
+          "type": "string"
+        },
         "month": {
           "default": "måned",
           "description": "Translation of \"month\" (singular). The default value is `måned`.",
@@ -435,6 +441,12 @@
           "default": "Laatst bijgewerkt",
           "description": "Translation of \"Last updated in\". The default value is `Laatst bijgewerkt`.",
           "title": "Last Updated",
+          "type": "string"
+        },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
           "type": "string"
         },
         "month": {
@@ -611,6 +623,12 @@
           "title": "Last Updated",
           "type": "string"
         },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
+          "type": "string"
+        },
         "month": {
           "default": "month",
           "description": "Translation of \"month\" (singular). The default value is `month`.",
@@ -723,6 +741,12 @@
           "title": "Last Updated",
           "type": "string"
         },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
+          "type": "string"
+        },
         "month": {
           "default": "mois",
           "description": "Translation of \"month\" (singular). The default value is `mois`.",
@@ -815,6 +839,12 @@
           "default": "Zuletzt aktualisiert",
           "description": "Translation of \"Last updated in\". The default value is `Zuletzt aktualisiert`.",
           "title": "Last Updated",
+          "type": "string"
+        },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
           "type": "string"
         },
         "month": {
@@ -911,6 +941,12 @@
           "title": "Last Updated",
           "type": "string"
         },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
+          "type": "string"
+        },
         "month": {
           "default": "महीना",
           "description": "Translation of \"month\" (singular). The default value is `महीना`.",
@@ -1003,6 +1039,12 @@
           "default": "Terakhir diperbarui",
           "description": "Translation of \"Last updated in\". The default value is `Terakhir diperbarui`.",
           "title": "Last Updated",
+          "type": "string"
+        },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
           "type": "string"
         },
         "month": {
@@ -1099,6 +1141,12 @@
           "title": "Last Updated",
           "type": "string"
         },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
+          "type": "string"
+        },
         "month": {
           "default": "mese",
           "description": "Translation of \"month\" (singular). The default value is `mese`.",
@@ -1193,6 +1241,12 @@
           "title": "Last Updated",
           "type": "string"
         },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
+          "type": "string"
+        },
         "month": {
           "default": "月",
           "description": "Translation of \"month\" (singular). The default value is `月`.",
@@ -1285,6 +1339,12 @@
           "default": "마지막 업데이트",
           "description": "Translation of \"Last updated in\". The default value is `마지막 업데이트`.",
           "title": "Last Updated",
+          "type": "string"
+        },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
           "type": "string"
         },
         "month": {
@@ -1508,6 +1568,12 @@
           "title": "Last Updated",
           "type": "string"
         },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
+          "type": "string"
+        },
         "month": {
           "default": "个月",
           "description": "Translation of \"month\" (singular). The default value is `个月`.",
@@ -1680,6 +1746,12 @@
           "default": "Última atualização",
           "description": "Translation of \"Last updated in\". The default value is `Última atualização`.",
           "title": "Last Updated",
+          "type": "string"
+        },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
           "type": "string"
         },
         "month": {
@@ -1881,6 +1953,12 @@
           "default": "Последнее обновление",
           "description": "Translation of \"Last updated in\". The default value is `Последнее обновление`.",
           "title": "Last Updated",
+          "type": "string"
+        },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
           "type": "string"
         },
         "month": {
@@ -2131,6 +2209,12 @@
           "title": "Last Updated",
           "type": "string"
         },
+        "in_preposition": {
+          "default": "en",
+          "description": "Translation of \"in\". The default value is `en`.",
+          "title": "In Preposition",
+          "type": "string"
+        },
         "month": {
           "default": "mes",
           "description": "Translation of \"month\" (singular). The default value is `mes`.",
@@ -2223,6 +2307,12 @@
           "default": "Son güncelleme",
           "description": "Translation of \"Last updated in\". The default value is `Son güncelleme`.",
           "title": "Last Updated",
+          "type": "string"
+        },
+        "in_preposition": {
+          "default": "in",
+          "description": "Translation of \"in\". The default value is `in`.",
+          "title": "In Preposition",
           "type": "string"
         },
         "month": {
@@ -3456,7 +3546,7 @@
       "additionalProperties": false,
       "properties": {
         "main_column": {
-          "default": "**INSTITUTION**, DEGREE in AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS",
+          "default": "**INSTITUTION**, DEGREE IN_PREPOSITION AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS",
           "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
@@ -3488,7 +3578,7 @@
       "additionalProperties": false,
       "properties": {
         "main_column": {
-          "default": "**INSTITUTION**, DEGREE in AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS",
+          "default": "**INSTITUTION**, DEGREE IN_PREPOSITION AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS",
           "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
@@ -3520,7 +3610,7 @@
       "additionalProperties": false,
       "properties": {
         "main_column": {
-          "default": "**INSTITUTION**, DEGREE in AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS",
+          "default": "**INSTITUTION**, DEGREE IN_PREPOSITION AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS",
           "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"
@@ -3552,7 +3642,7 @@
       "additionalProperties": false,
       "properties": {
         "main_column": {
-          "default": "**INSTITUTION**\n*DEGREE* *in* *AREA*\nSUMMARY\nHIGHLIGHTS",
+          "default": "**INSTITUTION**\n*DEGREE* *IN_PREPOSITION* *AREA*\nSUMMARY\nHIGHLIGHTS",
           "description": "Template for education entry main column. Available placeholders:\n- `INSTITUTION`: Institution name\n- `AREA`: Field of study/major\n- `DEGREE`: Degree type (e.g., BS, PhD)\n- `SUMMARY`: Summary text\n- `HIGHLIGHTS`: Bullet points list\n- `LOCATION`: Location text\n- `DATE`: Formatted date or date range\n\nYou can also add arbitrary keys to entries and use them as UPPERCASE placeholders.\n\nThe default value is `**INSTITUTION**, AREA\\nSUMMARY\\nHIGHLIGHTS`.",
           "title": "Main Column",
           "type": "string"

--- a/src/rendercv/renderer/templater/entry_templates_from_input.py
+++ b/src/rendercv/renderer/templater/entry_templates_from_input.py
@@ -50,6 +50,7 @@ def render_entry_templates[EntryType: Entry](
     entry_fields: dict[str, str | str] = {
         key.upper(): value for key, value in entry.model_dump(exclude_none=True).items()
     }
+    entry_fields["IN_PREPOSITION"] = locale.in_preposition
 
     # Handle special placeholders:
     if "HIGHLIGHTS" in entry_fields:

--- a/src/rendercv/schema/models/design/other_themes/engineeringclassic.yaml
+++ b/src/rendercv/schema/models/design/other_themes/engineeringclassic.yaml
@@ -29,7 +29,7 @@ design:
       space_between_items: "0.12cm"
   templates:
     education_entry:
-      main_column: "**INSTITUTION**, DEGREE in AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS"
+      main_column: "**INSTITUTION**, DEGREE IN_PREPOSITION AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS"
       date_and_location_column: DATE
       degree_column: null
     normal_entry:

--- a/src/rendercv/schema/models/design/other_themes/engineeringresumes.yaml
+++ b/src/rendercv/schema/models/design/other_themes/engineeringresumes.yaml
@@ -51,7 +51,7 @@ design:
       space_between_bullet_and_text: 0.3em
   templates:
     education_entry:
-      main_column: "**INSTITUTION**, DEGREE in AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS"
+      main_column: "**INSTITUTION**, DEGREE IN_PREPOSITION AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS"
       date_and_location_column: DATE
       degree_column: null
     normal_entry:

--- a/src/rendercv/schema/models/design/other_themes/moderncv.yaml
+++ b/src/rendercv/schema/models/design/other_themes/moderncv.yaml
@@ -43,7 +43,7 @@ design:
       space_between_bullet_and_text: 0.3em
   templates:
     education_entry:
-      main_column: "**INSTITUTION**, DEGREE in AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS"
+      main_column: "**INSTITUTION**, DEGREE IN_PREPOSITION AREA -- LOCATION\nSUMMARY\nHIGHLIGHTS"
       date_and_location_column: DATE
       degree_column: null
     normal_entry:

--- a/src/rendercv/schema/models/design/other_themes/sb2nov.yaml
+++ b/src/rendercv/schema/models/design/other_themes/sb2nov.yaml
@@ -34,7 +34,7 @@ design:
       nested_bullet: "◦"
   templates:
     education_entry:
-      main_column: "**INSTITUTION**\n*DEGREE* *in* *AREA*\nSUMMARY\nHIGHLIGHTS"
+      main_column: "**INSTITUTION**\n*DEGREE* *IN_PREPOSITION* *AREA*\nSUMMARY\nHIGHLIGHTS"
       degree_column: null
       date_and_location_column: "*LOCATION*\n*DATE*"
     normal_entry:

--- a/src/rendercv/schema/models/locale/english_locale.py
+++ b/src/rendercv/schema/models/locale/english_locale.py
@@ -18,6 +18,11 @@ class EnglishLocale(BaseModelWithoutExtraKeys):
             'Translation of "Last updated in". The default value is `Last updated in`.'
         ),
     )
+    in_preposition: str = pydantic.Field(
+        default="in",
+        alias="in",
+        description='Translation of "in". The default value is `in`.',
+    )
     month: str = pydantic.Field(
         default="month",
         description='Translation of "month" (singular). The default value is `month`.',

--- a/src/rendercv/schema/models/locale/english_locale.py
+++ b/src/rendercv/schema/models/locale/english_locale.py
@@ -20,7 +20,6 @@ class EnglishLocale(BaseModelWithoutExtraKeys):
     )
     in_preposition: str = pydantic.Field(
         default="in",
-        alias="in",
         description='Translation of "in". The default value is `in`.',
     )
     month: str = pydantic.Field(

--- a/src/rendercv/schema/models/locale/other_locales/spanish.yaml
+++ b/src/rendercv/schema/models/locale/other_locales/spanish.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=../../../../../../schema.json
 locale:
   language: spanish
+  in_preposition: en
   last_updated: Última actualización
   month: mes
   months: meses


### PR DESCRIPTION
Templates other than classic include a hardcoded "in" between the institution and area when rendering. This PR adds a "in_preposition" keyword to locales so it can be informed in other languages. Currently, it is added just in Spanish.