### PR TITLE
Update docker run command in docs

### DIFF
--- a/docs/developer_guide/dockerfile.md
+++ b/docs/developer_guide/dockerfile.md
@@ -22,7 +22,7 @@ But Docker makes sense if you want:
 
 The RenderCV Docker image is a ready-made environment with Python and RenderCV pre-installed. Just run:
 ```bash
-docker run -v "$PWD":/work -w /work ghcr.io/rendercv/rendercv new "Your Name"
+docker run --rm -v "$PWD":/work -u $(id -u):$(id -g) -e HOME=/tmp -w /work ghcr.io/rendercv/rendercv new "Your Name"
 ```
 
 ## How the Image Gets Published

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -29,7 +29,7 @@
         Docker image is available at [ghcr.io/rendercv/rendercv](https://github.com/rendercv/rendercv/pkgs/container/rendercv).
 
         ```bash
-        docker run -v "$PWD":/work -w /work ghcr.io/rendercv/rendercv new "Your Name"
+        docker run --rm -v "$PWD":/work -u $(id -u):$(id -g) -e HOME=/tmp -w /work ghcr.io/rendercv/rendercv new "Your Name"
         ```
 
 ## Quick Start


### PR DESCRIPTION
Updated [Docker command shown in Getting Started](https://docs.rendercv.com/user_guide/#__tabbed_1_4) docs
- Added `-u` to avoid permissions issue (rendercv has UID `999`, usually a linux user has UID `1000`)
- Added `--rm` to avoid creating leftover containers

**Fixes `PermissionError: [Errno 13] Permission denied: 'Your_Name_CV.yaml'` when running the Docker command from docs**