### PR TITLE
Fix EducationEntry location placement [MARKDOWN]

### DIFF
--- a/src/rendercv/renderer/templater/templates/markdown/entries/EducationEntry.j2.md
+++ b/src/rendercv/renderer/templater/templates/markdown/entries/EducationEntry.j2.md
@@ -6,6 +6,7 @@
 
 {% endif -%}
 {% for line in entry.date_and_location_column.splitlines() %}
+
 {{ line }}
 
 {% endfor %}

--- a/tests/renderer/testdata/test_markdown/full.md
+++ b/tests/renderer/testdata/test_markdown/full.md
@@ -1175,11 +1175,13 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
+
 Sept 2021
 
 
 
 ## **Boğaziçi University**, Mechanical Engineering
+
 
 
 
@@ -1191,11 +1193,13 @@ Sept 2015 – present
 
 
 
+
 June 2020
 
 
 
 ## **Boğaziçi University**, Mechanical Engineering
+
 
 
 
@@ -1231,6 +1235,7 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
+
 Sept 2021
 
 
@@ -1238,6 +1243,7 @@ Sept 2021
 ## **Boğaziçi University**, Mechanical Engineering
 
 **BS**
+
 
 Sept 2015 – present
 
@@ -1247,6 +1253,7 @@ Sept 2015 – present
 
 **BS**
 
+
 June 2020
 
 
@@ -1255,6 +1262,7 @@ June 2020
 
 **BS**
 
+
 Istanbul, Turkey
 
 
@@ -1287,29 +1295,34 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
-Sept 2021
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
 
 Sept 2021
 
 
 
 ## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2021
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
 
 
 
 Istanbul, Turkey
 
+
 Sept 2021
 
 
 
 ## **Boğaziçi University**, Mechanical Engineering
+
 
 
 
@@ -1320,6 +1333,7 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 ## **Boğaziçi University**, Mechanical Engineering
+
 
 
 
@@ -1338,6 +1352,7 @@ Sept 2021
 
 
 ## **Boğaziçi University**, Mechanical Engineering
+
 
 
 
@@ -1349,7 +1364,9 @@ Sept 2015 – June 2020
 
 
 
+
 Istanbul, Turkey
+
 
 Sept 2015 – present
 
@@ -1359,18 +1376,20 @@ Sept 2015 – present
 
 
 
-Sept 2015 – present
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
 
 Sept 2015 – present
 
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2015 – present
+
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
@@ -1387,7 +1406,9 @@ Sept 2015 – present
 
 
 
+
 Istanbul, Turkey
+
 
 June 2020
 
@@ -1397,18 +1418,20 @@ June 2020
 
 
 
-June 2020
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
 
 June 2020
 
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+June 2020
+
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
@@ -1422,6 +1445,7 @@ June 2020
 
 
 ## **Boğaziçi University**, Mechanical Engineering
+
 
 
 
@@ -1435,6 +1459,7 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
+
 Istanbul, Turkey
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
@@ -1471,13 +1496,6 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
-Sept 2021
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
 
 Sept 2021
 
@@ -1486,9 +1504,20 @@ Sept 2021
 ## **Boğaziçi University**, Mechanical Engineering
 
 **BS**
+
+
+Sept 2021
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
 
 Istanbul, Turkey
 
+
 Sept 2021
 
 
@@ -1496,6 +1525,7 @@ Sept 2021
 ## **Boğaziçi University**, Mechanical Engineering
 
 **BS**
+
 
 Sept 2021
 
@@ -1506,6 +1536,7 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 ## **Boğaziçi University**, Mechanical Engineering
 
 **BS**
+
 
 Sept 2021
 
@@ -1524,6 +1555,7 @@ Sept 2021
 ## **Boğaziçi University**, Mechanical Engineering
 
 **BS**
+
 
 Sept 2015 – June 2020
 
@@ -1533,7 +1565,9 @@ Sept 2015 – June 2020
 
 **BS**
 
+
 Istanbul, Turkey
+
 
 Sept 2015 – present
 
@@ -1543,18 +1577,20 @@ Sept 2015 – present
 
 **BS**
 
-Sept 2015 – present
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
 
 Sept 2015 – present
 
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Sept 2015 – present
+
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
@@ -1571,7 +1607,9 @@ Sept 2015 – present
 
 **BS**
 
+
 Istanbul, Turkey
+
 
 June 2020
 
@@ -1581,36 +1619,9 @@ June 2020
 
 **BS**
 
-June 2020
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
 
 June 2020
 
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
 Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
 
@@ -1619,7 +1630,8 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
-Istanbul, Turkey
+
+June 2020
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
@@ -1637,7 +1649,19 @@ Istanbul, Turkey
 
 **BS**
 
+
+Istanbul, Turkey
+
 Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
@@ -1653,125 +1677,7 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 ## **Boğaziçi University**, Mechanical Engineering
 
-
-
-Sept 2021
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2021
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2021
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2021
+**BS**
 
 Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
@@ -1791,7 +1697,159 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
+
+Sept 2021
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
 Istanbul, Turkey
+
+
+Sept 2021
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
 
 Sept 2015 – June 2020
 
@@ -1801,621 +1859,6 @@ Sept 2015 – June 2020
 
 
 
-Sept 2015 – June 2020
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2015 – June 2020
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2015 – present
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2015 – present
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2015 – present
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-June 2020
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-June 2020
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-June 2020
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2021
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-Sept 2021
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-Sept 2021
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-Sept 2015 – June 2020
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2015 – June 2020
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2015 – June 2020
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-Sept 2015 – present
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-Sept 2015 – present
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2015 – present
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-June 2020
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-June 2020
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-June 2020
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2021
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
 
 Sept 2015 – June 2020
 
@@ -2427,7 +1870,6 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
-Istanbul, Turkey
 
 Sept 2015 – June 2020
 
@@ -2447,9 +1889,25 @@ Sept 2015 – June 2020
 
 
 
-Sept 2015 – June 2020
+
+Istanbul, Turkey
+
+
+Sept 2015 – present
 
 Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2015 – present
 
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
@@ -2467,7 +1925,6 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
-Istanbul, Turkey
 
 Sept 2015 – present
 
@@ -2489,7 +1946,42 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
+
 Istanbul, Turkey
+
+
+June 2020
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+June 2020
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
 
 June 2020
 
@@ -2509,79 +2001,10 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 ## **Boğaziçi University**, Mechanical Engineering
 
-**BS**
+
+
 
 Istanbul, Turkey
-
-Sept 2021
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
-
-Sept 2021
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Sept 2021
 
 Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
@@ -2601,7 +2024,27 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
+
+Sept 2021
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
 Istanbul, Turkey
+
+
+Sept 2021
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
 
 Sept 2021
 
@@ -2613,7 +2056,6 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
-Istanbul, Turkey
 
 Sept 2021
 
@@ -2633,6 +2075,85 @@ Sept 2021
 
 **BS**
 
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
 Sept 2021
 
 Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
@@ -2653,21 +2174,11 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
+
 Istanbul, Turkey
 
-Sept 2021
 
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+Sept 2015 – June 2020
 
 
 
@@ -2675,7 +2186,6 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
-Istanbul, Turkey
 
 Sept 2015 – June 2020
 
@@ -2687,7 +2197,6 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
-Istanbul, Turkey
 
 Sept 2015 – June 2020
 
@@ -2707,10 +2216,26 @@ Sept 2015 – June 2020
 
 **BS**
 
-Sept 2015 – June 2020
+
+Istanbul, Turkey
+
+
+Sept 2015 – present
 
 Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2015 – present
+
 - Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
 
 - Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
@@ -2727,7 +2252,6 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
-Istanbul, Turkey
 
 Sept 2015 – present
 
@@ -2749,7 +2273,633 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
+
 Istanbul, Turkey
+
+
+June 2020
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+June 2020
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+June 2020
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2015 – June 2020
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2015 – June 2020
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Sept 2015 – June 2020
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+Sept 2015 – present
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
+
+June 2020
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2015 – June 2020
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2015 – June 2020
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Sept 2015 – June 2020
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
+
+Sept 2015 – present
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
 
 June 2020
 
@@ -2771,7 +2921,9 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
+
 Istanbul, Turkey
+
 
 Sept 2021
 
@@ -2783,7 +2935,9 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
+
 Istanbul, Turkey
+
 
 Sept 2021
 
@@ -2803,27 +2957,6 @@ Sept 2021
 
 
 
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-
-
-Istanbul, Turkey
 
 Sept 2021
 
@@ -2845,7 +2978,9 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
+
 Istanbul, Turkey
+
 
 Sept 2021
 
@@ -2867,7 +3002,33 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
+
 Istanbul, Turkey
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+
+
+
+Istanbul, Turkey
+
 
 Sept 2015 – June 2020
 
@@ -2889,7 +3050,9 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
+
 Istanbul, Turkey
+
 
 Sept 2021
 
@@ -2901,7 +3064,9 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
+
 Istanbul, Turkey
+
 
 Sept 2021
 
@@ -2921,27 +3086,6 @@ Sept 2021
 
 **BS**
 
-Sept 2021
-
-Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
-
-
-
-## **Boğaziçi University**, Mechanical Engineering
-
-**BS**
-
-Istanbul, Turkey
 
 Sept 2021
 
@@ -2963,7 +3107,9 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
+
 Istanbul, Turkey
+
 
 Sept 2021
 
@@ -2985,7 +3131,33 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
+
 Istanbul, Turkey
+
+
+Sept 2021
+
+Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did *this* and this is a **bold** [link](https://example.com). But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+  - Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+- Did that. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure.
+
+
+
+## **Boğaziçi University**, Mechanical Engineering
+
+**BS**
+
+
+Istanbul, Turkey
+
 
 Sept 2015 – June 2020
 
@@ -3007,7 +3179,9 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 
 
+
 Istanbul, Turkey
+
 
 Sept 2021
 
@@ -3029,7 +3203,9 @@ Did *this* and this is a **bold** [link](https://example.com). But I must explai
 
 **BS**
 
+
 Istanbul, Turkey
+
 
 Sept 2021
 


### PR DESCRIPTION
# Fix EducationEntry location placement

For the markdown renderer, the location of an EducationEntry is placed on the same line as the name of the institution, but should be on the subsequent line akin to the ExperienceEntry. This is a one-line change.

## The ExperienceEntry

<img width="316" height="132" alt="Screenshot 2026-01-13 at 11 21 22" src="https://github.com/user-attachments/assets/9b2d2695-08ca-4d3b-96be-b020e7d1fbb2" />

## Before the change

<img width="441" height="152" alt="Screenshot 2026-01-13 at 11 18 53" src="https://github.com/user-attachments/assets/5adeb5e4-3aa1-43b1-8e64-c9fdce675e5e" />

## After the change

<img width="358" height="192" alt="Screenshot 2026-01-13 at 11 19 11" src="https://github.com/user-attachments/assets/dee8693d-24c4-4846-8e22-74e4f6cdcdfe" />
