### PR TITLE
fix: :bug: design file not applying with settings file

### DIFF
--- a/src/rendercv/schema/rendercv_model_builder.py
+++ b/src/rendercv/schema/rendercv_model_builder.py
@@ -61,11 +61,11 @@ def build_rendercv_dictionary(
     input_dict = read_yaml(main_input_file_path_or_contents)
     input_dict.setdefault("settings", {}).setdefault("render_command", {})
 
-    # Optional YAML overlays
+    # Optional YAML overlays (process settings first to avoid overwriting design/locale paths)
     yaml_overlays: dict[str, pathlib.Path | str | None] = {
+        "settings": kwargs.get("settings_file_path_or_contents"),
         "design": kwargs.get("design_file_path_or_contents"),
         "locale": kwargs.get("locale_file_path_or_contents"),
-        "settings": kwargs.get("settings_file_path_or_contents"),
     }
 
     for key, path_or_contents in yaml_overlays.items():

--- a/src/rendercv/schema/rendercv_model_builder.py
+++ b/src/rendercv/schema/rendercv_model_builder.py
@@ -74,6 +74,7 @@ def build_rendercv_dictionary(
                 input_dict[key] = read_yaml(path_or_contents)[key]
             elif isinstance(path_or_contents, pathlib.Path):
                 input_dict["settings"]["render_command"][key] = path_or_contents
+            input_dict.setdefault("settings", {}).setdefault("render_command", {})
 
     # Optional render-command overrides
     render_overrides: dict[str, pathlib.Path | str | bool | None] = {

--- a/tests/schema/test_rendercv_model_builder.py
+++ b/tests/schema/test_rendercv_model_builder.py
@@ -518,6 +518,44 @@ class TestBuildRendercvModel:
         # Model should have the design from the file applied
         assert model.design.theme == "sb2nov"
 
+    def test_design_overlay_applies_with_settings_overlay(
+        self, create_yaml_file_fixture
+    ):
+        """Ensure design overlay applies even when settings overlay is provided."""
+        main_input = {
+            "cv": {"name": "John Doe"},
+            "design": {"theme": "classic"},
+        }
+        settings_overlay = {
+            "settings": {
+                "render_command": {
+                    "typst_path": "rendercv_output/NAME_IN_SNAKE_CASE_CV.typ",
+                    "pdf_path": "rendercv_output/NAME_IN_SNAKE_CASE_CV.pdf",
+                    "markdown_path": "rendercv_output/NAME_IN_SNAKE_CASE_CV.md",
+                    "html_path": "rendercv_output/NAME_IN_SNAKE_CASE_CV.html",
+                    "png_path": "rendercv_output/NAME_IN_SNAKE_CASE_CV.png",
+                    "dont_generate_markdown": False,
+                    "dont_generate_html": False,
+                    "dont_generate_typst": False,
+                    "dont_generate_pdf": False,
+                    "dont_generate_png": False,
+                }
+            }
+        }
+        design_overlay = {"design": {"theme": "sb2nov"}}
+
+        main_file = create_yaml_file_fixture("main.yaml", main_input)
+        settings_file = create_yaml_file_fixture("settings.yaml", settings_overlay)
+        design_file = create_yaml_file_fixture("design.yaml", design_overlay)
+
+        dictionary, model = build_rendercv_dictionary_and_model(
+            main_file,
+            settings_file_path_or_contents=settings_file,
+            design_file_path_or_contents=design_file,
+        )
+
+        assert model.design.theme != "classic"
+
     def test_locale_file_overlay_loads_and_applies(self, create_yaml_file_fixture):
         """Test that locale file overlay is loaded from settings.render_command.locale and applied to model."""
         main_input = {

--- a/tests/schema/test_rendercv_model_builder.py
+++ b/tests/schema/test_rendercv_model_builder.py
@@ -571,7 +571,7 @@ class TestBuildRendercvModel:
         settings_file = create_yaml_file_fixture("settings.yaml", settings_overlay)
         design_file = create_yaml_file_fixture("design.yaml", design_overlay)
 
-        dictionary, model = build_rendercv_dictionary_and_model(
+        _, model = build_rendercv_dictionary_and_model(
             main_file,
             settings_file_path_or_contents=settings_file,
             design_file_path_or_contents=design_file,

--- a/tests/schema/test_rendercv_model_builder.py
+++ b/tests/schema/test_rendercv_model_builder.py
@@ -131,6 +131,29 @@ class TestBuildRendercvDictionary:
         assert result["design"]["theme"] == "classic"
         assert result["locale"]["language"] == "english"
 
+    def test_settings_overlay_without_render_command_allows_design_path_overlay(
+        self, create_yaml_file_fixture
+    ):
+        main_input = {
+            "cv": {"name": "John Doe"},
+            "design": {"theme": "classic"},
+        }
+        settings_overlay = {"settings": {"current_date": "2024-01-01"}}
+        design_overlay = {"design": {"theme": "sb2nov"}}
+
+        main_file = create_yaml_file_fixture("main.yaml", main_input)
+        settings_file = create_yaml_file_fixture("settings.yaml", settings_overlay)
+        design_file = create_yaml_file_fixture("design.yaml", design_overlay)
+
+        result = build_rendercv_dictionary(
+            main_file,
+            settings_file_path_or_contents=settings_file,
+            design_file_path_or_contents=design_file,
+        )
+
+        assert result["settings"]["current_date"] == "2024-01-01"
+        assert result["settings"]["render_command"]["design"] == design_file
+
     @pytest.mark.parametrize(
         ("override_key", "override_value"),
         [


### PR DESCRIPTION
## Summary
  - Closes #640 
  - Reorder overlay processing so later overlays can override earlier ones consistently
  - Ensure `settings.render_command` is initialized after applying overlays to avoid missing-dict errors

## Testing
- Added 2 new tests
- All tests pass