### PR TITLE
fix: prevent degree title clipping and hyphenation in classic theme

### DIFF
--- a/src/rendercv/renderer/templater/templates/typst/Preamble.j2.typ
+++ b/src/rendercv/renderer/templater/templates/typst/Preamble.j2.typ
@@ -81,3 +81,48 @@
     day: {{ settings.current_date.day }},
   ),
 )
+
+// Override the education-entry function to increase the degree column width:
+#let education-entry(main-column, date-and-location-column, degree-column: none, main-column-second-row: none) = {
+  metadata("skip-content-area")
+
+  context {
+    let config = rendercv-config.get()
+    let entries-space-between-columns = config.at("entries-space-between-columns")
+
+    // The width was hardcoded to 1cm in previous versions, which is too small for some degrees.
+    // We increased it to 2.4cm and disabled hyphenation to prevent word breaks like "certifica-do":
+    let degree-column-width = 2.4cm 
+
+    regular-entry(
+      if degree-column != none {
+        grid(
+          columns: (degree-column-width, 1fr),
+          column-gutter: entries-space-between-columns + 0.4cm,
+          align: (left, auto),
+          [
+            #set text(hyphenate: false)
+            #degree-column
+          ],
+          [
+            #main-column
+          ],
+        )
+      } else {
+        main-column
+      },
+      date-and-location-column,
+      main-column-second-row: if main-column-second-row != none {
+        [
+          #block(
+            main-column-second-row,
+            inset: (
+              left: if degree-column != none { degree-column-width + entries-space-between-columns } else { 0cm },
+              right: 0cm,
+            ),
+          )
+        ]
+      } else { none },
+    )
+  }
+}


### PR DESCRIPTION
Description
This PR fixes a layout issue in the classic theme where degree titles are often clipped or hyphenated incorrectly due to a very narrow hardcoded column width.

The Problem
In the current implementation, the degree-column in the Typst template has a fixed width of 1cm. While this might suffice for short acronyms like "GPA", it is insufficient for many professional degree titles, especially in languages like Spanish or Catalan, where titles like "Certificado Profesional" or "Máster" are common. This leads to:

Aggressive and often incorrect hyphenation (e.g., "certifica-do").
Text clipping or overlapping when hyphenation is not possible.
Poor visual separation between the degree title and the institution name.
Proposed Changes
Increased Column Width: Adjusted the degree-column-width from 1cm to 2.4cm in the Typst preamble to accommodate longer titles comfortably.
Disabled Hyphenation: Added #set text(hyphenate: false) specifically for the degree column to ensure titles remain intact and readable.
Improved Gutter Spacing: Added an additional 0.4cm to the column-gutter between the degree and the main column to improve legibility and provide better visual breathing room.
Template Override: The changes were implemented as a clean override in the education-entry function within the Typst rendering logic.
Impact
Users with non-English CVs or those with long degree titles will see a significant improvement in the professional appearance of their education section, with no more broken words or cramped layouts.

