### PR TITLE
Fix Custom Fonts folder not found using relative path

### DIFF
--- a/src/rendercv/cli/render_command/render_command.py
+++ b/src/rendercv/cli/render_command/render_command.py
@@ -197,7 +197,7 @@ def cli_command_render(
     ] = None,
     extra_data_model_override_arguments: typer.Context = None,  # ty: ignore[invalid-parameter-default]
 ):
-    input_file_path = pathlib.Path(input_file_name)
+    input_file_path = pathlib.Path(input_file_name).absolute()
 
     # Resolve design/locale overlay files from YAML settings when not
     # provided via CLI flags. collect_input_file_paths already handles

--- a/tests/cli/render_command/test_render_command.py
+++ b/tests/cli/render_command/test_render_command.py
@@ -165,6 +165,18 @@ class TestCliCommandRender:
         rendercv_output = input_file.parent / "rendercv_output"
         assert (rendercv_output / "John_Doe_CV.pdf").exists()
 
+    @patch("rendercv.cli.render_command.render_command.run_rendercv")
+    def test_converts_relative_input_path_to_absolute(
+        self, mock_run, input_file, default_arguments
+    ):
+        cli_command_render(
+            input_file_name=input_file.name,
+            **default_arguments,
+        )
+
+        called_path = mock_run.call_args[0][0]
+        assert called_path.is_absolute()
+
     @patch("rendercv.cli.render_command.render_command.run_function_if_files_change")
     def test_calls_watcher_when_watch_flag_is_true(
         self, mock_watcher, input_file, default_arguments


### PR DESCRIPTION
Fix #689

If users create a `fonts` folder for Custom Fonts, `rendercv` will not detect the `fonts` folder given by users when running the following command. Fix it by always using the absolute path of the YAML file.

```sh
rendercv render CV.yaml
```

