### PR TITLE
Add `cv.postnominals` field for post-nominal letters

### DIFF
--- a/docs/user_guide/yaml_input_structure/cv.md
+++ b/docs/user_guide/yaml_input_structure/cv.md
@@ -7,28 +7,32 @@ The `cv` field begins with your personal information. All fields are optional. R
 ```yaml
 cv:
   name: John Doe
+  postnominals: # (1)!
+    - PhD
+    - FRCS
   headline: Machine Learning Engineer
   location: San Francisco, CA
-  email: john@example.com # (1)!
-  phone: +14155551234 # (2)!
-  website: https://johndoe.dev # (3)!
+  email: john@example.com # (2)!
+  phone: +14155551234 # (3)!
+  website: https://johndoe.dev # (4)!
   photo: photo.jpg
   social_networks:
-    - network: LinkedIn # (4)!
+    - network: LinkedIn # (5)!
       username: johndoe
     - network: GitHub
       username: johndoe
   custom_connections:
-    - placeholder: Book a call # (5)!
+    - placeholder: Book a call # (6)!
       url: https://cal.com/johndoe
       fontawesome_icon: calendar-days
 ```
 
-1. Multiple emails can be provided as a list.
-2. Multiple phone numbers can be provided as a list.
-3. Multiple websites can be provided as a list.
-4. Available social networks: << available_social_networks >>
-5. Custom connections let you add any extra link (or plain text if `url` is omitted) with your own display text (`placeholder`) and a Font Awesome icon name (e.g., `calendar-days`, `envelope`). For the list of available icons, see [fontawesome.com/search](https://fontawesome.com/search).
+1. Multiple post-nominals can be provided as a list.
+2. Multiple emails can be provided as a list.
+3. Multiple phone numbers can be provided as a list.
+4. Multiple websites can be provided as a list.
+5. Available social networks: << available_social_networks >>
+6. Custom connections let you add any extra link (or plain text if `url` is omitted) with your own display text (`placeholder`) and a Font Awesome icon name (e.g., `calendar-days`, `envelope`). For the list of available icons, see [fontawesome.com/search](https://fontawesome.com/search).
 
 ## Sections
 

--- a/schema.json
+++ b/schema.json
@@ -271,6 +271,40 @@
           ],
           "title": "Name"
         },
+        "postnominals": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Post-nominal letters to display as a subheading below your name. Provide as a list; they will be joined with ', ' in the output.",
+          "examples": [
+            [
+              "PhD"
+            ],
+            [
+              "MD",
+              "FACS"
+            ],
+            [
+              "BSc",
+              "MSc",
+              "PhD"
+            ],
+            [
+              "FRCS",
+              "FRCP"
+            ]
+          ],
+          "title": "Postnominals"
+        },
         "headline": {
           "anyOf": [
             {

--- a/src/rendercv/renderer/templater/model_processor.py
+++ b/src/rendercv/renderer/templater/model_processor.py
@@ -90,6 +90,11 @@ def process_model(
     rendercv_model.cv.headline = apply_string_processors(
         rendercv_model.cv.headline, string_processors
     )
+    if rendercv_model.cv.postnominals is not None:
+        rendercv_model.cv.postnominals = [
+            apply_string_processors(item, string_processors)
+            for item in rendercv_model.cv.postnominals
+        ]
     rendercv_model.cv._connections = compute_connections(rendercv_model, file_type)
     rendercv_model.cv._top_note = render_top_note_template(
         rendercv_model.design.templates.top_note,

--- a/src/rendercv/renderer/templater/templates/markdown/Header.j2.md
+++ b/src/rendercv/renderer/templater/templates/markdown/Header.j2.md
@@ -1,6 +1,9 @@
 {% if cv.name %}
 # {{ cv.name }}'s CV
 {% endif %}
+{% if cv.postnominals %}
+## {{ cv.postnominals | join(", ") }}
+{% endif %}
 
 {% if cv.phone %}
 - Phone: {{cv.phone|replace("tel:", "")|replace("-"," ")}}

--- a/src/rendercv/renderer/templater/templates/typst/Header.j2.typ
+++ b/src/rendercv/renderer/templater/templates/typst/Header.j2.typ
@@ -23,6 +23,10 @@
 = {{ cv.name }}
 {% endif %}
 
+{% if cv.postnominals %}
+  #headline([{{ cv.postnominals | join(", ") }}])
+
+{% endif %}
 {% if cv.headline %}
   #headline([{{ cv.headline }}])
 

--- a/src/rendercv/schema/models/cv/cv.py
+++ b/src/rendercv/schema/models/cv/cv.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, Self
+from typing import Any, Self, cast
 
 import pydantic
 import pydantic_extra_types.phone_numbers as pydantic_phone_numbers
@@ -32,6 +32,14 @@ class Cv(BaseModelWithoutExtraKeys):
     name: str | None = pydantic.Field(
         default=None,
         examples=["John Doe", "Jane Smith"],
+    )
+    postnominals: list[str] | None = pydantic.Field(
+        default=None,
+        description=(
+            "Post-nominal letters to display as a subheading below your name. Provide"
+            " as a list; they will be joined with ', ' in the output."
+        ),
+        examples=[["PhD"], ["MD", "FACS"], ["BSc", "MSc", "PhD"], ["FRCS", "FRCP"]],
     )
     headline: str | None = pydantic.Field(
         default=None,
@@ -163,7 +171,9 @@ class Cv(BaseModelWithoutExtraKeys):
             return data
 
         # Capture the input order before validation
-        key_order = list(data.keys()) if isinstance(data, dict) else []
+        key_order: list[str] = []
+        if isinstance(data, dict):
+            key_order = cast(list[str], list(data.keys()))
 
         # Let Pydantic do its validation
         instance = handler(data)

--- a/src/rendercv/schema/sample_content.yaml
+++ b/src/rendercv/schema/sample_content.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=../../../schema.json
 cv:
   name: John Doe
+  postnominals:
   headline:
   location: San Francisco, CA
   email: john.doe@email.com

--- a/tests/renderer/templater/test_model_processor.py
+++ b/tests/renderer/templater/test_model_processor.py
@@ -175,6 +175,22 @@ class TestProcessModel:
             assert result.cv._connections[0].startswith("#link(")
             assert "jane@example.com" in result.cv._connections[0]
 
+    def test_markdown_preserves_postnominals_unescaped(self):
+        cv = Cv.model_validate({"name": "Jane Doe", "postnominals": ["PhD @", "MSc #"]})
+        rendercv_model = RenderCVModel(cv=cv)
+
+        result = process_model(rendercv_model, "markdown")
+
+        assert result.cv.postnominals == ["PhD @", "MSc #"]
+
+    def test_typst_escapes_postnominals_special_characters(self):
+        cv = Cv.model_validate({"name": "Jane Doe", "postnominals": ["PhD @", "MSc #"]})
+        rendercv_model = RenderCVModel(cv=cv)
+
+        result = process_model(rendercv_model, "typst")
+
+        assert result.cv.postnominals == ["PhD \\@", "MSc \\#"]
+
     def test_handles_cv_with_no_sections(self):
         cv_data = {
             "name": "Jane Doe",

--- a/tests/renderer/templater/test_model_processor.py
+++ b/tests/renderer/templater/test_model_processor.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from datetime import date as Date
 from unittest.mock import patch
 
@@ -33,7 +34,10 @@ def recorder():
 
 class TestProcessFields:
     def test_applies_processors_in_order(self):
-        processors = [lambda s: s.upper(), lambda s: f"{s}!"]
+        processors: list[Callable[[str], str]] = [
+            lambda s: s.upper(),
+            lambda s: f"{s}!",
+        ]
         result = process_fields("content", processors)
         assert result == "CONTENT!"
 


### PR DESCRIPTION
## Summary

Adds a new `cv.postnominals` field that renders post-nominal letters (e.g., PhD, FRCS, CEng) as a styled subheading directly below the name (based on headline).

```yaml
cv:
  name: Jane Smith
  postnominals:
    - MD
    - FRCP
    - FRCPCH
```

Items are provided as a YAML list and joined with ", " at render time, producing MD, FRCP, FRCPCH beneath the name.

# Changes

- cv.py - Added postnominals: list[str] | None field to the CV model
- model_processor.py — Postnominals are passed through string processors (markdown→Typst conversion, bold_keywords) consistent with name and headline
- Header.j2.typ — Renders using #headline([...]) between name and headline
- Header.j2.md — Renders as ## ... (h2), smaller than the h1 name
- schema.json — Regenerated to reflect the new field
- sample_content.yaml — Updated with an example
- test_model_processor.py — lambda types couldn't be inferred as Callable[[str], str]. Fixed by adding an explicit type annotation to processors. (Previously failing `just check`)
- Docs updated