### PR TITLE
Setup multi-platform docker build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,14 +124,18 @@ jobs:
           images: |
             ghcr.io/${{ github.repository }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build and push Docker images
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4


### PR DESCRIPTION
See: https://docs.docker.com/build/ci/github-actions/multi-platform/

Avoids getting the following warning when running on an ARM mac, or having to pass `--arch amd64` when using Apple's [`container`](https://github.com/apple/container)

> WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested

Tested locally by running

```sh
docker build --platform linux/arm64,linux/amd64  -t render:qms -f Dockerfile .
```

And then verifying that I'm not getting the warning when

```sh
docker run -v "$PWD":/work -w /work render:qms render cv.yaml
```

It might need some tweaks when running in Github Actions, we'll have to test.