### PR TITLE
Fix #703: add --collect-submodules rich to PyInstaller build

### DIFF
--- a/scripts/create_executable.py
+++ b/scripts/create_executable.py
@@ -43,6 +43,8 @@ with tempfile.TemporaryDirectory() as temp_dir:
             "rendercv",
             "--collect-all",
             "rendercv_fonts",
+            "--collect-submodules",
+            "rich",
             "--distpath",
             "bin",
             str(rendercv_file),


### PR DESCRIPTION
## Summary

- `rich>=14.3.0` dynamically imports unicode data modules (e.g. `rich._unicode_data.unicode17-0-0`) via `importlib`, which PyInstaller's static analysis cannot detect
- Added `--collect-submodules rich` to the PyInstaller command in `scripts/create_executable.py` to ensure all `rich` submodules are bundled in the binary
- This fixes the `ModuleNotFoundError` that makes v2.7/v2.8 binaries unusable

Closes #703

## Changes

- `scripts/create_executable.py`: Added `--collect-submodules rich` flag to the PyInstaller invocation (2 lines added)

## Test plan

- Build executable with `just create-executable`
- Verify `./bin/rendercv-linux-x86_64 --help` and `./bin/rendercv-linux-x86_64 render cv.yaml` work without `ModuleNotFoundError`
- The existing `create-executables.yaml` CI workflow will validate across all 4 platforms (Linux x86_64, Linux ARM64, macOS, Windows)