### PR TITLE
Bug Fix: Only Bold Unbolded Keywords

### DIFF
--- a/src/rendercv/renderer/templater/string_processor.py
+++ b/src/rendercv/renderer/templater/string_processor.py
@@ -106,7 +106,14 @@ def make_keywords_bold(string: str, keywords: list[str]) -> str:
         return string
 
     pattern = build_keyword_matcher_pattern(frozenset(keywords), word_boundary=True)
-    return pattern.sub(lambda m: f"**{m.group(0)}**", string)
+    unbold_pattern = re.compile(r"(.*?)(\*\*[^\n]+?\*\*)|(.+)$", re.DOTALL)
+
+    def handle_unbold_match(m1: re.Match) -> str:
+        g1 = pattern.sub(lambda m2: f"**{m2.group(0)}**", m1.group(1) or "")
+        g2 = m1.group(2) or ""
+        g3 = pattern.sub(lambda m2: f"**{m2.group(0)}**", m1.group(3) or "")
+        return g1 + g2 + g3
+    return unbold_pattern.sub(handle_unbold_match, string)
 
 
 def substitute_placeholders(string: str, placeholders: dict[str, str]) -> str:

--- a/src/rendercv/renderer/templater/string_processor.py
+++ b/src/rendercv/renderer/templater/string_processor.py
@@ -113,6 +113,7 @@ def make_keywords_bold(string: str, keywords: list[str]) -> str:
         g2 = m1.group(2) or ""
         g3 = pattern.sub(lambda m2: f"**{m2.group(0)}**", m1.group(3) or "")
         return g1 + g2 + g3
+
     return unbold_pattern.sub(handle_unbold_match, string)
 
 

--- a/tests/renderer/templater/test_string_processor.py
+++ b/tests/renderer/templater/test_string_processor.py
@@ -116,8 +116,18 @@ class TestMakeKeywordsBold:
     def test_keyword_inside_bold_is_never_double_bolded(self, keyword: str) -> None:
         text = f"before **{keyword}** after"
         result = make_keywords_bold(text, [keyword])
-        assert f"**{keyword}**" in result  # original bold preserved
-        assert "****" not in result  # no double-bold wrapping
+        assert result == text
+
+    @settings(deadline=None)
+    @given(
+        keyword=st.text(min_size=1, max_size=20).filter(
+            lambda s: s.strip() and "\n" not in s and "**" not in s
+        ),
+    )
+    def test_keyword_inside_bold_range_is_not_bolded(self, keyword: str) -> None:
+        text = f"before **before {keyword} after** after"
+        result = make_keywords_bold(text, [keyword])
+        assert result == text
 
     @settings(deadline=None)
     @given(

--- a/tests/renderer/templater/test_string_processor.py
+++ b/tests/renderer/templater/test_string_processor.py
@@ -84,6 +84,58 @@ class TestMakeKeywordsBold:
     def test_returns_expected_output(self, text, keywords, expected):
         assert make_keywords_bold(text, keywords) == expected
 
+    @pytest.mark.parametrize(
+        ("text", "keywords", "expected"),
+        [
+            # Completely inside existing bold range (existing)
+            ("zero **one** two", ["one"], "zero **one** two"),
+            ("**zero one two**", ["one"], "**zero one two**"),
+            # Keyword outside AND inside bold — outside must be bolded, inside must not
+            ("one **one** one", ["one"], "**one** **one** **one**"),
+            ("two **one** one", ["one"], "two **one** **one**"),
+            # Multiple bold spans
+            ("**one** plain **one**", ["one"], "**one** plain **one**"),
+            ("**one** one **one**", ["one"], "**one** **one** **one**"),
+            # Keyword that straddles a bold boundary (should bold the outside part)
+            (
+                "on**e** word",
+                ["one"],
+                "on**e** word",
+            ),  # not a valid bold span, so "on" is outside
+        ],
+    )
+    def test_handles_existing_bold_ranges(self, text, keywords, expected):
+        assert make_keywords_bold(text, keywords) == expected
+
+    @settings(deadline=None)
+    @given(
+        keyword=st.text(min_size=1, max_size=20).filter(
+            lambda s: s.strip() and "\n" not in s and "**" not in s
+        ),
+    )
+    def test_keyword_inside_bold_is_never_double_bolded(self, keyword: str) -> None:
+        text = f"before **{keyword}** after"
+        result = make_keywords_bold(text, [keyword])
+        assert f"**{keyword}**" in result  # original bold preserved
+        assert "****" not in result  # no double-bold wrapping
+
+    @settings(deadline=None)
+    @given(
+        keyword=st.text(min_size=1, max_size=20).filter(
+            lambda s: s.strip() and "\n" not in s and "**" not in s
+        ),
+        other=st.text(min_size=1, max_size=20).filter(
+            lambda s: s.strip() and "**" not in s and "\n" not in s
+        ),
+    )
+    def test_keyword_outside_bold_span_gets_bolded(
+        self, keyword: str, other: str
+    ) -> None:
+        assume(keyword != other)
+        text = f"{keyword} **{other}**"
+        result = make_keywords_bold(text, [keyword])
+        assert f"**{keyword}**" in result
+
     @settings(deadline=None)
     @given(text=st.text(max_size=100))
     def test_empty_keywords_is_identity(self, text: str) -> None:


### PR DESCRIPTION
Consider the following case,

```
zero **one** two
```
if the keyword is `one` it will attempt to rebold it, resulting in
```
zero ****one**** two
```
which the underlying `markdown` package does not render as expected.
```html
<p>zero <strong><em>*one</em></strong>* two</p>
```

Another case,
```
**zero one two**
```
 would result in,
```
**zero **one** two**
```
`markdown` produces the following html
```html
<p><strong>zero </strong>one<strong> two</strong></p>
```
which unbolds the keyword instead of bolding it. 

This pr attempts to bypass these limitation by excluding already bolded ranges from the replacement.