### PR TITLE
Add section_labels to locale for localized section headings

### DIFF
--- a/src/rendercv/renderer/templater/model_processor.py
+++ b/src/rendercv/renderer/templater/model_processor.py
@@ -130,6 +130,9 @@ def process_model(
         return rendercv_model
 
     for section in rendercv_model.cv.rendercv_sections:
+        section.title = rendercv_model.locale.section_labels.get(
+            section.key, section.title
+        )
         section.title = apply_string_processors(section.title, string_processors)
         show_time_span = (
             section.snake_case_title

--- a/src/rendercv/schema/models/cv/section.py
+++ b/src/rendercv/schema/models/cv/section.py
@@ -82,12 +82,20 @@ characteristic_entry_fields = get_characteristic_entry_fields(available_entry_mo
 
 class BaseRenderCVSection(BaseModelWithoutExtraKeys):
     title: str
+    key: str = pydantic.Field(
+        default="",
+        description="Original YAML section key, preserved for style selectors and locale label lookups.",
+    )
     entry_type: str
     entries: list[Any]
 
     @property
     def snake_case_title(self) -> str:
-        return self.title.lower().replace(" ", "_")
+        return (
+            self.key.lower().replace(" ", "_")
+            if self.key
+            else self.title.lower().replace(" ", "_")
+        )
 
 
 def create_section_models(
@@ -354,6 +362,7 @@ def get_rendercv_sections(
             # SectionBase is used so that entries are not validated again:
             section = BaseRenderCVSection(
                 title=formatted_title,
+                key=title,
                 entry_type=entry_type_name,
                 entries=entries,
             )

--- a/src/rendercv/schema/models/locale/english_locale.py
+++ b/src/rendercv/schema/models/locale/english_locale.py
@@ -56,6 +56,16 @@ class EnglishLocale(BaseModelWithoutExtraKeys):
         default_factory=Phrases,
         description="Locale-specific phrases used in entry templates as placeholders.",
     )
+    section_labels: dict[str, str] = pydantic.Field(
+        default_factory=dict,
+        description=(
+            "Optional mapping from canonical snake_case section keys to localized"
+            " display titles. When a key is present, its value overrides the"
+            " auto-generated title in the rendered output. Keys not listed fall back"
+            " to the default Title Case conversion."
+            " Example: `{summary: 'In breve', experience: 'Esperienza lavorativa'}`."
+        ),
+    )
     # From https://web.library.yale.edu/cataloging/months
     month_abbreviations: Annotated[list[str], at.Len(min_length=12, max_length=12)] = (
         pydantic.Field(

--- a/src/rendercv/schema/models/locale/locale.py
+++ b/src/rendercv/schema/models/locale/locale.py
@@ -33,6 +33,7 @@ def discover_other_locales() -> list[type[EnglishLocale]]:
             class_name_suffix="Locale",
             module_name="rendercv.schema.models.locale",
             require_all_fields=True,
+            optional_fields={"section_labels"},
         )
         discovered.append(locale_model)
 

--- a/src/rendercv/schema/variant_pydantic_model_generator.py
+++ b/src/rendercv/schema/variant_pydantic_model_generator.py
@@ -63,6 +63,7 @@ def create_variant_pydantic_model[T: pydantic.BaseModel](
     class_name_suffix: str,
     module_name: str,
     require_all_fields: bool = False,
+    optional_fields: set[str] | None = None,
 ) -> type[T]:
     """Create Pydantic model variant with customized defaults.
 
@@ -93,12 +94,19 @@ def create_variant_pydantic_model[T: pydantic.BaseModel](
         module_name: Module path for the generated class.
         require_all_fields: If True, every field in the base model must be
             present in defaults (checked recursively for nested models).
+        optional_fields: Fields excluded from the `require_all_fields` check.
+            Useful for base-model fields that have sensible defaults and do not
+            need per-locale translation (e.g., `section_labels`).
 
     Returns:
         New model class with overrides applied.
     """
     validate_defaults_against_base(
-        defaults, base_class, variant_name, require_all_fields=require_all_fields
+        defaults,
+        base_class,
+        variant_name,
+        require_all_fields=require_all_fields,
+        optional_fields=optional_fields,
     )
 
     # Sanitize defaults to remove ruamel.yaml metadata
@@ -139,6 +147,7 @@ def validate_defaults_against_base(
     variant_name: str,
     *,
     require_all_fields: bool = False,
+    optional_fields: set[str] | None = None,
 ) -> None:
     """Validate that all fields in defaults exist in the base model.
 
@@ -154,6 +163,7 @@ def validate_defaults_against_base(
             present in defaults. Nested Pydantic model fields are checked
             recursively. Useful for locales where falling back to English
             defaults is incorrect.
+        optional_fields: Fields excluded from the `require_all_fields` check.
     """
     base_fields = base_class.model_fields
 
@@ -166,7 +176,8 @@ def validate_defaults_against_base(
             raise RenderCVInternalError(message)
 
     if require_all_fields:
-        missing_fields = set(base_fields.keys()) - set(defaults.keys())
+        excluded = optional_fields or set()
+        missing_fields = set(base_fields.keys()) - set(defaults.keys()) - excluded
         if missing_fields:
             message = (
                 f"Missing fields {sorted(missing_fields)} in defaults for"

--- a/tests/renderer/templater/test_model_processor.py
+++ b/tests/renderer/templater/test_model_processor.py
@@ -204,6 +204,63 @@ class TestProcessModel:
 
         assert result.settings.pdf_title == "John Doe - Resume 2024"
 
+    def test_section_labels_override_rendered_section_title(self):
+        cv = Cv.model_validate(
+            {
+                "name": "Jane Doe",
+                "sections": {
+                    "summary": ["Builds reliable tools."],
+                },
+            }
+        )
+        rendercv_model = RenderCVModel(cv=cv)
+        rendercv_model.locale.section_labels = {"summary": "In breve"}
+
+        result = process_model(rendercv_model, "markdown")
+
+        assert result.cv.rendercv_sections[0].title == "In breve"
+
+    def test_section_labels_do_not_change_snake_case_title(self):
+        cv = Cv.model_validate(
+            {
+                "name": "Jane Doe",
+                "sections": {
+                    "summary": ["Builds reliable tools."],
+                },
+            }
+        )
+        rendercv_model = RenderCVModel(cv=cv)
+        rendercv_model.locale.section_labels = {"summary": "In breve"}
+
+        result = process_model(rendercv_model, "markdown")
+
+        section = result.cv.rendercv_sections[0]
+        assert section.title == "In breve"
+        assert section.snake_case_title == "summary"
+
+    def test_missing_section_label_falls_back_to_default_title(self):
+        cv = Cv.model_validate(
+            {
+                "name": "Jane Doe",
+                "sections": {
+                    "experience": [
+                        {
+                            "company": "Example Co.",
+                            "position": "Engineer",
+                            "start_date": "2020-01-01",
+                            "end_date": "2021-01-01",
+                        }
+                    ],
+                },
+            }
+        )
+        rendercv_model = RenderCVModel(cv=cv)
+        rendercv_model.locale.section_labels = {"summary": "In breve"}
+
+        result = process_model(rendercv_model, "markdown")
+
+        assert result.cv.rendercv_sections[0].title == "Experience"
+
 
 class TestDownloadPhotoFromUrl:
     def test_skips_when_photo_is_none(self):


### PR DESCRIPTION
Closes #741

## Problem

The locale catalog translates dates and months but not section titles. 
Headings in the rendered PDF are always derived from the YAML key via `dictionary_key_to_proper_section_title`, with no override mechanism.
Non-English CVs have to choose between canonical snake_case keys (producing English headings) or non-canonical keys (losing portability across language variants).

## Solution

Add an optional `section_labels: dict[str, str]` field to the locale catalog. Keys are canonical YAML section keys; values are the localized headings to render instead.


```yaml
locale:
  language: italian
  section_labels:
    summary: "In breve"
    experience: "Esperienza lavorativa"
    education: "Formazione"
Keys not listed fall back to the existing Title Case conversion.
Existing CVs and all other locale YAMLs require no changes.
```

### Implementation

- `EnglishLocale` — new `section_labels: dict[str, str]` field, `default_factory=dict`, so it is fully optional.
- `BaseRenderCVSection` — new `key: str` field preserving the original YAML key through the pipeline. `snake_case_title` now derives from `key` instead of the (possibly-translated) display title, keeping `show_time_spans_in` and Typst style selectors stable after translation.
- `model_processor.process_model` — applies `section_labels` mapping before `apply_string_processors`, so localized titles still go through Markdown and keyword-bold processing.
- `create_variant_pydantic_model` — new `optional_fields` parameter exempts `section_labels from` the `require_all_fields` completeness check, so none of the 21 existing locale YAMLs need to be touched.

