### PR TITLE
Use uv.lock as single source of truth for pre-commit tool versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,24 +4,28 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-toml
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+  - repo: local
     hooks:
       - id: codespell
+        name: codespell
+        language: system
+        entry: uv run --frozen codespell
         args:
           - --skip=src/rendercv/schema/models/locale/other_locales/*
           - --exclude-file=schema.json
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.7
-    hooks:
       - id: ruff-check
+        name: ruff check
+        language: system
+        entry: uv run --frozen ruff check --force-exclude
+        types_or: [python, pyi]
       - id: ruff-format
-  - repo: local
-    hooks:
+        name: ruff format
+        language: system
+        entry: uv run --frozen ruff format --force-exclude
+        types_or: [python, pyi]
       - id: ty-check
-        name: ty-check
-        language: python
-        entry: ty check src tests
+        name: ty check
+        language: system
+        entry: uv run --frozen ty check src tests
         pass_filenames: false
         args: [--python=.venv/]
-        additional_dependencies: ["ty>=0.0.24"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,6 @@ repos:
         name: codespell
         language: system
         entry: uv run --frozen codespell
-        args:
-          - --skip=src/rendercv/schema/models/locale/other_locales/*
-          - --exclude-file=schema.json
       - id: ruff-check
         name: ruff check
         language: system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,4 +226,5 @@ addopts = [
 testpaths = ["tests"]
 
 [tool.codespell]
-skip = "*.md"
+skip = "*.md,*.pdf,*/typst_fontawesome/*,*/other_locales/*"
+exclude-file = "schema.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ rendercv = "rendercv.cli.entry_point:entry_point"
 [dependency-groups]
 dev = [
   "black>=26.3.1",  # Format the code
+  "codespell>=2.4.2",
   "hypothesis>=6.151.9",  # Property-based testing
   "prek>=0.3.6",  # Run checks before committing (pre-commit alternative)
   "pytest>=9.0.2",  # Run tests

--- a/uv.lock
+++ b/uv.lock
@@ -201,6 +201,15 @@ wheels = [
 ]
 
 [[package]]
+name = "codespell"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9d/1d0903dff693160f893ca6abcabad545088e7a2ee0a6deae7c24e958be69/codespell-2.4.2.tar.gz", hash = "sha256:3c33be9ae34543807f088aeb4832dfad8cb2dae38da61cac0a7045dd376cfdf3", size = 352058, upload-time = "2026-03-05T18:10:42.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/a1/52fa05533e95fe45bcc09bcf8a503874b1c08f221a4e35608017e0938f55/codespell-2.4.2-py3-none-any.whl", hash = "sha256:97e0c1060cf46bd1d5db89a936c98db8c2b804e1fdd4b5c645e82a1ec6b1f886", size = 353715, upload-time = "2026-03-05T18:10:41.398Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1227,6 +1236,7 @@ create-executable = [
 ]
 dev = [
     { name = "black" },
+    { name = "codespell" },
     { name = "hypothesis" },
     { name = "prek" },
     { name = "pytest" },
@@ -1270,6 +1280,7 @@ provides-extras = ["full"]
 create-executable = [{ name = "pyinstaller", specifier = ">=6.17.0" }]
 dev = [
     { name = "black", specifier = ">=26.3.1" },
+    { name = "codespell", specifier = ">=2.4.2" },
     { name = "hypothesis", specifier = ">=6.151.9" },
     { name = "prek", specifier = ">=0.3.6" },
     { name = "pytest", specifier = ">=9.0.2" },


### PR DESCRIPTION
Closes #743

## Problem

`.pre-commit-config.yaml` pinned tool versions independently from `uv.lock`, creating two separate sources of truth that could silently drift. The concrete failure reported in #743: the `ty-check` hook used `additional_dependencies ["ty>=0.0.24"]`, which pre-commit resolved to the latest available `ty` release — newer than the version locked in `uv.lock`.
The newer release tightened type inference, turning existing `# ty: ignore` comments into errors and making `just check` fail on a fresh clone.

The same structural problem affected `ruff`, which was pinned to a specific tag in the `astral-sh/ruff-pre-commit` external repo independently of `uv.lock`.

## Solution

Replace all external pre-commit repos for Python tools (`ruff`, `codespell`, `ty`) with local hooks that invoke tools via `uv run --frozen`. This way the version is always determined by `uv.lock` — no version number appears in `.pre-commit-config.yaml` itself.

- `ruff` and `ty` were already in the dev dependency group; their external repo blocks (`astral-sh/ruff-pre-commit`, and the `additional_dependencies` trick for `ty`) are replaced by `language: system` hooks.
- `codespell` is added to the dev dependency group and locked in `uv.lock`, then made a local hook as well.
- `pre-commit/pre-commit-hooks` remains an external repo since it has no equivalent package in the project.

Codespell configuration (skip patterns, exclude file) is moved from inline hook args into `[tool.codespell]` in `pyproject.toml`, so the settings apply consistently regardless of how codespell is invoked.
The skip list is also extended to cover PDF files (which produce binary false positives) and the bundled `typst_fontawesome` third-party library.

## Testing

`uv run --frozen codespell` exits clean.  
`uv run --frozen prek validate-config .pre-commit-config.yaml` reports
success.
