### PR TITLE
Add secrets overlay support to render command

### DIFF
--- a/src/rendercv/cli/render_command/render_command.py
+++ b/src/rendercv/cli/render_command/render_command.py
@@ -65,6 +65,16 @@ def cli_command_render(
             help='The "settings" field\'s YAML input file.',
         ),
     ] = None,
+    secrets: Annotated[
+        pathlib.Path | None,
+        typer.Option(
+            "--secrets",
+            help=(
+                "A YAML file whose values are merged into the input file before"
+                " validation."
+            ),
+        ),
+    ] = None,
     typst_path: Annotated[
         pathlib.Path | None,
         typer.Option(
@@ -201,7 +211,9 @@ def cli_command_render(
     # Resolve design/locale overlay files from YAML settings when not
     # provided via CLI flags. collect_input_file_paths already handles
     # parsing the YAML and resolving paths relative to the input file.
-    resolved_files = collect_input_file_paths(input_file_path, design, locale, settings)
+    resolved_files = collect_input_file_paths(
+        input_file_path, design, locale, settings, secrets
+    )
     if design is None and "design" in resolved_files:
         design = resolved_files["design"]
     if locale is None and "locale" in resolved_files:
@@ -213,6 +225,7 @@ def cli_command_render(
         "settings_yaml_file": (
             settings.read_text(encoding="utf-8") if settings else None
         ),
+        "secrets_yaml_file": secrets.read_text(encoding="utf-8") if secrets else None,
         "output_folder": output_folder,
         "typst_path": typst_path,
         "pdf_path": pdf_path,

--- a/src/rendercv/cli/render_command/run_rendercv.py
+++ b/src/rendercv/cli/render_command/run_rendercv.py
@@ -77,7 +77,8 @@ def collect_input_file_paths(
     design: pathlib.Path | None = None,
     locale: pathlib.Path | None = None,
     settings: pathlib.Path | None = None,
-) -> dict[Literal["input", "design", "locale", "settings"], pathlib.Path]:
+    secrets: pathlib.Path | None = None,
+) -> dict[Literal["input", "design", "locale", "settings", "secrets"], pathlib.Path]:
     """Collect all input file paths involved in a render.
 
     Why:
@@ -92,13 +93,14 @@ def collect_input_file_paths(
         design: CLI-provided design file path.
         locale: CLI-provided locale file path.
         settings: CLI-provided settings file path.
+        secrets: CLI-provided secrets/general overlay file path.
 
     Returns:
-        Mapping from role ("input", "design", "locale", "settings") to path.
+        Mapping from role ("input", "design", "locale", "settings", "secrets") to path.
     """
-    files: dict[Literal["input", "design", "locale", "settings"], pathlib.Path] = {
-        "input": input_file_path
-    }
+    files: dict[
+        Literal["input", "design", "locale", "settings", "secrets"], pathlib.Path
+    ] = {"input": input_file_path}
 
     if design:
         files["design"] = design
@@ -106,6 +108,8 @@ def collect_input_file_paths(
         files["locale"] = locale
     if settings:
         files["settings"] = settings
+    if secrets:
+        files["secrets"] = secrets
 
     # Also include design/locale files referenced in the YAML itself
     # (CLI flags take precedence, so skip if already provided).

--- a/src/rendercv/exception.py
+++ b/src/rendercv/exception.py
@@ -6,6 +6,7 @@ type YamlSource = Literal[
     "design_yaml_file",
     "locale_yaml_file",
     "settings_yaml_file",
+    "secrets_yaml_file",
 ]
 type OverlaySourceKey = Literal["design", "locale", "settings"]
 type YamlLocation = tuple[tuple[int, int], tuple[int, int]]

--- a/src/rendercv/schema/pydantic_error_handling.py
+++ b/src/rendercv/schema/pydantic_error_handling.py
@@ -30,12 +30,40 @@ unwanted_locations = (
     "constrained-str",
     "function-",
 )
+type OverlaySourceMap = dict[tuple[str, ...], tuple[YamlSource, CommentedMap]]
+
+
+def get_yaml_source_data_for_location(
+    location: tuple[str, ...],
+    overlay_sources: OverlaySourceMap | dict[str, CommentedMap] | None,
+) -> tuple[YamlSource, CommentedMap] | None:
+    """Find the most specific overlay source for a validation location."""
+    if not overlay_sources:
+        return None
+
+    # Backward compatibility for tests and callers that still pass
+    # {"design": commented_map} style overlay metadata.
+    first_value = next(iter(overlay_sources.values()))
+    if isinstance(first_value, CommentedMap):
+        legacy_sources = cast(dict[str, CommentedMap], overlay_sources)
+        if location and location[0] in legacy_sources:
+            source_key = cast(OverlaySourceKey, location[0])
+            return OVERLAY_SOURCE_TO_YAML_SOURCE[source_key], legacy_sources[source_key]
+        return None
+
+    source_map = cast(OverlaySourceMap, overlay_sources)
+    for index in range(len(location), 0, -1):
+        path = location[:index]
+        if path in source_map:
+            return source_map[path]
+
+    return None
 
 
 def parse_plain_pydantic_error(
     plain_error: pydantic_core.ErrorDetails,
     input_dictionary: CommentedMap | dict[str, Any],
-    overlay_sources: dict[str, CommentedMap] | None = None,
+    overlay_sources: OverlaySourceMap | dict[str, CommentedMap] | None = None,
 ) -> RenderCVValidationError:
     """Transform raw Pydantic error into user-friendly validation error with YAML coordinates.
 
@@ -98,10 +126,9 @@ def parse_plain_pydantic_error(
     # CommentedMap for coordinate lookup
     yaml_source: YamlSource = "main_yaml_file"
     coord_dict: CommentedMap | dict[str, Any] = input_dictionary
-    if overlay_sources and location and location[0] in overlay_sources:
-        source_key = cast(OverlaySourceKey, location[0])
-        yaml_source = OVERLAY_SOURCE_TO_YAML_SOURCE[source_key]
-        coord_dict = overlay_sources[source_key]
+    overlay_source_data = get_yaml_source_data_for_location(location, overlay_sources)
+    if overlay_source_data:
+        yaml_source, coord_dict = overlay_source_data
 
     location_for_coords = (
         location if plain_error["type"] != "missing" else location[:-1]
@@ -130,7 +157,7 @@ def parse_plain_pydantic_error(
 def parse_validation_errors(
     exception: pydantic.ValidationError,
     input_dictionary: CommentedMap | dict[str, Any],
-    overlay_sources: dict[str, CommentedMap] | None = None,
+    overlay_sources: OverlaySourceMap | dict[str, CommentedMap] | None = None,
 ) -> list[RenderCVValidationError]:
     """Extract all validation errors from Pydantic exception with deduplication.
 

--- a/src/rendercv/schema/rendercv_model_builder.py
+++ b/src/rendercv/schema/rendercv_model_builder.py
@@ -25,6 +25,7 @@ class BuildRendercvModelArguments(TypedDict, total=False):
     design_yaml_file: str | None
     locale_yaml_file: str | None
     settings_yaml_file: str | None
+    secrets_yaml_file: str | None
     output_folder: pathlib.Path | str | None
     typst_path: pathlib.Path | str | None
     pdf_path: pathlib.Path | str | None
@@ -37,6 +38,50 @@ class BuildRendercvModelArguments(TypedDict, total=False):
     dont_generate_pdf: bool | None
     dont_generate_png: bool | None
     overrides: dict[str, str] | None
+
+
+type OverlaySourceMap = dict[tuple[str, ...], tuple[YamlSource, CommentedMap]]
+
+
+def collect_yaml_paths(
+    yaml_object: CommentedMap | list,
+    prefix: tuple[str, ...] = (),
+) -> set[tuple[str, ...]]:
+    """Collect all paths present in a YAML object for source tracking."""
+    paths: set[tuple[str, ...]] = set()
+    if isinstance(yaml_object, CommentedMap):
+        for key, value in yaml_object.items():
+            path = (*prefix, str(key))
+            if isinstance(value, CommentedMap | list):
+                paths.update(collect_yaml_paths(value, path))
+            else:
+                paths.add(path)
+    elif isinstance(yaml_object, list):
+        for index, value in enumerate(yaml_object):
+            path = (*prefix, str(index))
+            paths.add(path)
+            if isinstance(value, CommentedMap | list):
+                paths.update(collect_yaml_paths(value, path))
+
+    return paths
+
+
+def merge_yaml_overlay(
+    dictionary: CommentedMap,
+    overlay: CommentedMap,
+) -> CommentedMap:
+    """Recursively merge a general YAML overlay into a base dictionary."""
+    for key, value in overlay.items():
+        if (
+            key in dictionary
+            and isinstance(dictionary[key], CommentedMap)
+            and isinstance(value, CommentedMap)
+        ):
+            merge_yaml_overlay(dictionary[key], value)
+        else:
+            dictionary[key] = value
+
+    return dictionary
 
 
 def get_yaml_error_location(error: ruamel.yaml.YAMLError) -> YamlLocation | None:
@@ -104,7 +149,7 @@ def read_yaml_with_validation_errors(
 def build_rendercv_dictionary(
     main_yaml_file: str,
     **kwargs: Unpack[BuildRendercvModelArguments],
-) -> tuple[CommentedMap, dict[str, CommentedMap]]:
+) -> tuple[CommentedMap, OverlaySourceMap]:
     """Merge main YAML with overlays and CLI overrides into final dictionary.
 
     Args:
@@ -112,7 +157,7 @@ def build_rendercv_dictionary(
         kwargs: Optional YAML overlay strings, output paths, generation flags, and CLI overrides.
 
     Returns:
-        Tuple of merged dictionary and overlay source CommentedMaps (for error reporting).
+        Tuple of merged dictionary and overlay source metadata (for error reporting).
     """
     input_dict = read_yaml_with_validation_errors(main_yaml_file, "main_yaml_file")
     input_dict.setdefault("settings", {}).setdefault("render_command", {})
@@ -123,14 +168,23 @@ def build_rendercv_dictionary(
         "locale": kwargs.get("locale_yaml_file"),
     }
 
-    overlay_sources: dict[str, CommentedMap] = {}
+    overlay_sources: OverlaySourceMap = {}
     for key, yaml_content in yaml_overlays.items():
         if yaml_content:
             overlay_cm = read_yaml_with_validation_errors(
                 yaml_content, OVERLAY_SOURCE_TO_YAML_SOURCE[key]
             )
             input_dict[key] = overlay_cm[key]
-            overlay_sources[key] = overlay_cm
+            overlay_sources[(key,)] = (OVERLAY_SOURCE_TO_YAML_SOURCE[key], overlay_cm)
+
+    secrets_yaml_file = kwargs.get("secrets_yaml_file")
+    if secrets_yaml_file:
+        secrets_cm = read_yaml_with_validation_errors(
+            secrets_yaml_file, "secrets_yaml_file"
+        )
+        input_dict = merge_yaml_overlay(input_dict, secrets_cm)
+        for path in collect_yaml_paths(secrets_cm):
+            overlay_sources[path] = ("secrets_yaml_file", secrets_cm)
 
     render_overrides: dict[str, pathlib.Path | str | bool | None] = {
         "output_folder": kwargs.get("output_folder"),
@@ -160,7 +214,7 @@ def build_rendercv_dictionary(
 def build_rendercv_model_from_commented_map(
     commented_map: CommentedMap | dict[str, Any],
     input_file_path: pathlib.Path | None = None,
-    overlay_sources: dict[str, CommentedMap] | None = None,
+    overlay_sources: OverlaySourceMap | None = None,
 ) -> RenderCVModel:
     """Validate merged dictionary and build Pydantic model with error mapping.
 

--- a/tests/cli/render_command/test_render_command.py
+++ b/tests/cli/render_command/test_render_command.py
@@ -16,6 +16,7 @@ class TestCliCommandRender:
             "design": None,
             "locale": None,
             "settings": None,
+            "secrets": None,
             "typst_path": None,
             "pdf_path": None,
             "markdown_path": None,
@@ -216,6 +217,23 @@ class TestCliCommandRender:
 
         typst_file = input_file.parent / "rendercv_output" / "John_Doe_CV.typ"
         assert expected_in_output in typst_file.read_text()
+
+    def test_uses_secrets_overlay_file(self, input_file, default_arguments):
+        secrets_file = input_file.parent / "secrets.yaml"
+        secrets_file.write_text(
+            'cv:\n  email: private@example.com\n  phone: "+14155552671"\n',
+            encoding="utf-8",
+        )
+
+        cli_command_render(
+            input_file_name=input_file,
+            **{**default_arguments, "secrets": secrets_file},
+        )
+
+        typst_file = input_file.parent / "rendercv_output" / "John_Doe_CV.typ"
+        typst = typst_file.read_text()
+        assert "private@example.com" in typst
+        assert "+1-415-555-2671" in typst
 
     @pytest.mark.parametrize(
         ("render_command_field", "config_content", "expected_in_output"),

--- a/tests/cli/render_command/test_run_rendercv.py
+++ b/tests/cli/render_command/test_run_rendercv.py
@@ -199,14 +199,17 @@ class TestCollectInputFilePaths:
         design_file.touch()
         settings_file = tmp_path / "settings.yaml"
         settings_file.touch()
+        secrets_file = tmp_path / "secrets.yaml"
+        secrets_file.touch()
 
         result = collect_input_file_paths(
-            yaml_file, design=design_file, settings=settings_file
+            yaml_file, design=design_file, settings=settings_file, secrets=secrets_file
         )
 
         assert result["input"] == yaml_file
         assert result["design"] == design_file
         assert result["settings"] == settings_file
+        assert result["secrets"] == secrets_file
 
     def test_includes_yaml_referenced_files(self, tmp_path):
         design_file = tmp_path / "my_design.yaml"

--- a/tests/schema/test_rendercv_model_builder.py
+++ b/tests/schema/test_rendercv_model_builder.py
@@ -61,8 +61,18 @@ class TestBuildRendercvDictionary:
         main_yaml = dictionary_to_yaml(main_input)
         overlay_yaml = dictionary_to_yaml(overlay_content)
 
-        kwargs = {f"{overlay_key}_yaml_file": overlay_yaml}
-        result, _ = build_rendercv_dictionary(main_yaml, **kwargs)  # pyright: ignore[reportArgumentType]
+        if overlay_key == "design":
+            result, _ = build_rendercv_dictionary(
+                main_yaml, design_yaml_file=overlay_yaml
+            )
+        elif overlay_key == "locale":
+            result, _ = build_rendercv_dictionary(
+                main_yaml, locale_yaml_file=overlay_yaml
+            )
+        else:
+            result, _ = build_rendercv_dictionary(
+                main_yaml, settings_yaml_file=overlay_yaml
+            )
 
         assert result[overlay_key] == overlay_content[overlay_key]
         assert result["cv"]["name"] == "John Doe"
@@ -349,8 +359,18 @@ class TestBuildRendercvDictionary:
         main_yaml = dictionary_to_yaml(main_input)
         overlay_yaml = dictionary_to_yaml(overlay_value)
 
-        kwargs = {f"{overlay_key}_yaml_file": overlay_yaml}
-        result, _ = build_rendercv_dictionary(main_yaml, **kwargs)  # pyright: ignore[reportArgumentType]
+        if overlay_key == "design":
+            result, _ = build_rendercv_dictionary(
+                main_yaml, design_yaml_file=overlay_yaml
+            )
+        elif overlay_key == "locale":
+            result, _ = build_rendercv_dictionary(
+                main_yaml, locale_yaml_file=overlay_yaml
+            )
+        else:
+            result, _ = build_rendercv_dictionary(
+                main_yaml, settings_yaml_file=overlay_yaml
+            )
 
         assert result[overlay_key] == overlay_value[overlay_key]
 
@@ -366,6 +386,85 @@ class TestBuildRendercvDictionary:
 
         assert result["design"] == {"theme": "sb2nov"}
         assert "font_size" not in result["design"]
+
+    def test_secrets_overlay_deep_merges_into_main_yaml(self, minimal_input_dict):
+        main_input = {
+            **minimal_input_dict,
+            "cv": {
+                "name": "Public Name",
+                "email": "public@example.com",
+                "sections": {"summary": [{"One public line.": "This remains public."}]},
+            },
+        }
+        main_yaml = dictionary_to_yaml(main_input)
+        secrets_yaml = dictionary_to_yaml(
+            {"cv": {"email": "private@example.com", "phone": "+14155552671"}}
+        )
+
+        result, _ = build_rendercv_dictionary(main_yaml, secrets_yaml_file=secrets_yaml)
+
+        assert result["cv"]["name"] == "Public Name"
+        assert result["cv"]["email"] == "private@example.com"
+        assert result["cv"]["phone"] == "+14155552671"
+        assert "summary" in result["cv"]["sections"]
+
+    def test_secrets_overlay_runs_before_cli_overrides(self, minimal_input_dict):
+        main_yaml = dictionary_to_yaml(minimal_input_dict)
+        secrets_yaml = dictionary_to_yaml({"cv": {"email": "private@example.com"}})
+
+        result, _ = build_rendercv_dictionary(
+            main_yaml,
+            secrets_yaml_file=secrets_yaml,
+            overrides={"cv.email": "override@example.com"},
+        )
+
+        assert result["cv"]["email"] == "override@example.com"
+
+    def test_invalid_secrets_yaml_raises_validation_error(self, minimal_input_dict):
+        main_yaml = dictionary_to_yaml(minimal_input_dict)
+        invalid_secrets_yaml = "cv:\n  email: test@example.com\n   phone: 123"
+
+        with pytest.raises(RenderCVUserValidationError) as exc_info:
+            build_rendercv_dictionary(main_yaml, secrets_yaml_file=invalid_secrets_yaml)
+
+        error = exc_info.value.validation_errors[0]
+        assert error.yaml_source == "secrets_yaml_file"
+
+    def test_validation_error_from_secrets_uses_secrets_source(
+        self, minimal_input_dict
+    ):
+        main_yaml = dictionary_to_yaml(minimal_input_dict)
+        secrets_yaml = dictionary_to_yaml({"cv": {"email": "not-an-email"}})
+
+        with pytest.raises(RenderCVUserValidationError) as exc_info:
+            build_rendercv_dictionary_and_model(
+                main_yaml, secrets_yaml_file=secrets_yaml
+            )
+
+        assert any(
+            error.yaml_source == "secrets_yaml_file"
+            and error.schema_location is not None
+            and error.schema_location[:2] == ("cv", "email")
+            for error in exc_info.value.validation_errors
+        )
+
+    def test_secrets_overlay_does_not_claim_unrelated_main_yaml_errors(self):
+        main_yaml = dictionary_to_yaml(
+            {"cv": {"name": 123}, "design": {"theme": "classic"}}
+        )
+        secrets_yaml = dictionary_to_yaml({"cv": {"email": "private@example.com"}})
+
+        with pytest.raises(RenderCVUserValidationError) as exc_info:
+            build_rendercv_dictionary_and_model(
+                main_yaml, secrets_yaml_file=secrets_yaml
+            )
+
+        assert any(
+            error.yaml_source == "main_yaml_file"
+            and error.schema_location is not None
+            and error.schema_location[:2] == ("cv", "name")
+            for error in exc_info.value.validation_errors
+        )
 
 
 class TestBuildRendercvModelFromDictionary:


### PR DESCRIPTION
Closes #740

## Summary
This adds support for a private YAML overlay file that is merged into the main input before Pydantic validation:

```bash
rendercv render cv.yaml --secrets secrets.yaml
The overlay is intentionally general-purpose, so users can keep public-safe mock values in their committed CV YAML and replace any subset of fields locally, such as cv.email, cv.phone, or cv.location, without breaking schema validation or watch mode.
```

## Implementation

- Adds secrets_yaml_file support to the model-building pipeline.
- Deep-merges the secrets YAML into the already-loaded input before validation.
- Tracks validation errors from values supplied by the secrets file as secrets_yaml_file, so errors point at the private overlay when applicable.
- Adds --secrets to rendercv render and includes the secrets file in watch-mode input tracking.
- Keeps CLI field overrides higher priority than the secrets overlay.

## Testing
Passing locally:

```bash
uv run pytest tests/schema/test_rendercv_model_builder.py tests/cli/render_command/test_run_rendercv.py tests/cli/render_command/test_render_command.py -q
uv run --frozen --all-extras ty check src tests
```

Note: uv run --frozen --all-extras prek run --all-files may fail on current main because of the pre-commit/ty version mismatch handled separately in #744. The remaining failure is unrelated to this feature branch.

## Non-goals / Security note
This is not a secret manager. The file is only read locally and merged before validation; users should keep it git-ignored.